### PR TITLE
[INTG-1521] Add basic SQL integration tests against DBs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
           MYSQL_USER: iauditor_exporter
           MYSQL_PASSWORD: iauditor_exporter
         options: >-
-          --health-cmd mysqladmin ping -h localhost
+          --health-cmd "mysqladmin ping -h localhost"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,10 @@
 name: Tests
 
 # yamllint disable-line rule:truthy
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened]
+  push:
 
 jobs:
   Unit-Tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,8 +191,9 @@ jobs:
       - name: Download all coverage results
         uses: actions/download-artifact@v2
 
-
       - name: Upload Coverage to Code Climate
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
           go test -coverprofile c.out ./...
           ./cc-test-reporter format-coverage -o codeclimate.unit.json --prefix $(go list -m)
 
-      - name: Upload Coverage Result
+      - name: Upload Coverage Result Artifact
         uses: actions/upload-artifact@v2
         with:
           name: codeclimate-unit
@@ -76,7 +76,18 @@ jobs:
           TEST_DB_DIALECT: postgres
           TEST_DB_CONN_STRING: "postgresql://iauditor_exporter:iauditor_exporter@localhost:5432/iauditor_exporter_db"
         run: |
-          go test ./... -tags=sql
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+          go test -coverprofile c.out ./... -tags=sql
+          ./cc-test-reporter format-coverage -o codeclimate.intg-postgresql.json --prefix $(go list -m)
+
+      - name: Upload Coverage Result Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: codeclimate-intg-postgresql
+          path: codeclimate.intg-postgresql.json
+          retention-days: 1
 
   MySQL-8-Integration-Tests:
     runs-on: ubuntu-latest
@@ -111,7 +122,18 @@ jobs:
           TEST_DB_DIALECT: mysql
           TEST_DB_CONN_STRING: "root:iauditor_exporter@tcp(localhost:3306)/iauditor_exporter_db?charset=utf8mb4&parseTime=True&loc=Local"
         run: |
-          go test ./... -tags=sql
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+          go test -coverprofile c.out ./... -tags=sql
+          ./cc-test-reporter format-coverage -o codeclimate.intg-mysql-8.json --prefix $(go list -m)
+
+      - name: Upload Coverage Result Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: codeclimate-intg-mysql-8
+          path: codeclimate.intg-mysql-8.json
+          retention-days: 1
 
 
   SQL-Server-Integration-Tests:
@@ -145,4 +167,34 @@ jobs:
           TEST_DB_DIALECT: sqlserver
           TEST_DB_CONN_STRING: "sqlserver://sa:iAuditorExporter12345@localhost:1433?database=master"
         run: |
-          go test ./... -tags=sql
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+          go test -coverprofile c.out ./... -tags=sql
+          ./cc-test-reporter format-coverage -o codeclimate.intg-sql-server.json --prefix $(go list -m)
+
+      - name: Upload Coverage Result Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: codeclimate-intg-sql-server
+          path: codeclimate.intg-sql-server.json
+          retention-days: 1
+
+  Upload-Coverage:
+    runs-on: ubuntu-latest
+    needs:
+      - Unit-Tests
+      - PostgreSQL-Integration-Tests
+      - MySQL-8-Integration-Tests
+      - SQL-Server-Integration-Tests
+    steps:
+      - name: Download all coverage results
+        uses: actions/download-artifact@v2
+
+
+      - name: Upload Coverage to Code Climate
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter sum-coverage codeclimate.*.json -p 4 -o codeclimate.total.json
+          ./cc-test-reporter upload-coverage -i codeclimate.total.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,7 +116,7 @@ jobs:
           SA_PASSWORD: "iAuditorExporter12345"
           ACCEPT_EULA: "Y"
         options: >-
-          --health-cmd "sqlcmd -S localhost -U sa -P iAuditorExporter12345 -Q \"SELECT 1\" || exit 1"
+          --health-cmd "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P iAuditorExporter12345 -Q \"SELECT 1\" || exit 1"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,3 +105,37 @@ jobs:
           TEST_DB_CONN_STRING: "root:iauditor_exporter@tcp(localhost:3306)/iauditor_exporter_db?charset=utf8mb4&parseTime=True&loc=Local"
         run: |
           go test ./... -tags=sql
+
+
+  SQL-Server-Integration-Tests:
+    runs-on: ubuntu-latest
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server
+        env:
+          SA_PASSWORD: "iAuditorExporter12345"
+          ACCEPT_EULA: "Y"
+        options: >-
+          --health-cmd "sqlcmd -S localhost -U sa -P iAuditorExporter12345 -Q \"SELECT 1\" || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 3306:3306
+
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Test & Coverage
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          TEST_DB_DIALECT: sqlserver
+          TEST_DB_CONN_STRING: "sqlserver://sa:iAuditorExporter12345@localhost:1433?database=master"
+        run: |
+          go test ./... -tags=sql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,3 +70,38 @@ jobs:
           TEST_DB_CONN_STRING: "postgresql://iauditor_exporter:iauditor_exporter@localhost:5432/iauditor_exporter_db"
         run: |
           go test ./... -tags=sql
+
+  MySQL-8-Integration-Tests:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: iauditor_exporter
+          MYSQL_DATABASE: iauditor_exporter_db
+          MYSQL_USER: iauditor_exporter
+          MYSQL_PASSWORD: iauditor_exporter
+        options: >-
+          --health-cmd mysqladmin ping -h localhost
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 3306:3306
+
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Test & Coverage
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          TEST_DB_DIALECT: mysql
+          TEST_DB_CONN_STRING: "root:iauditor_exporter@tcp(localhost:3306)/iauditor_exporter_db?charset=utf8mb4&parseTime=True&loc=Local"
+        run: |
+          go test ./... -tags=sql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,6 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
           TEST_DB_DIALECT: postgres
-          TEST_DB_CONN_STRING: "postgresql://iauditor_exporter:iauditor_exporter@localhost:5434/iauditor_exporter_db"
+          TEST_DB_CONN_STRING: "postgresql://iauditor_exporter:iauditor_exporter@localhost:5432/iauditor_exporter_db"
         run: |
           go test ./... -tags=sql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,5 +197,5 @@ jobs:
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
-          ./cc-test-reporter sum-coverage codeclimate.*.json -p 4 -o codeclimate.total.json
+          ./cc-test-reporter sum-coverage */codeclimate.*.json -p 4 -o codeclimate.total.json
           ./cc-test-reporter upload-coverage -i codeclimate.total.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,6 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
           TEST_DB_DIALECT: postgres
-          TEST_DB_CONN_STRING: "postgresql://iauditor_exporter:iauditor_exporter@localhost:5434/iauditor_exporter_db"
+          TEST_DB_CONN_STRING: "postgresql://iauditor_exporter:iauditor_exporter@postgres:5434/iauditor_exporter_db"
         run: |
           go test ./... -tags=sql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,13 +31,13 @@ jobs:
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
           go test -coverprofile c.out ./...
-          ./cc-test-reporter format-coverage -o codeclimate.unit.json --prefix $(go list -m)
+          ./cc-test-reporter format-coverage -o codeclimate.json --prefix $(go list -m)
 
       - name: Upload Coverage Result Artifact
         uses: actions/upload-artifact@v2
         with:
           name: codeclimate-unit
-          path: codeclimate.unit.json
+          path: codeclimate.json
           retention-days: 1
 
       - uses: actions/setup-python@v2
@@ -80,13 +80,13 @@ jobs:
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
           go test -coverprofile c.out ./... -tags=sql
-          ./cc-test-reporter format-coverage -o codeclimate.intg-postgresql.json --prefix $(go list -m)
+          ./cc-test-reporter format-coverage -o codeclimate.json --prefix $(go list -m)
 
       - name: Upload Coverage Result Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: codeclimate-intg-postgresql
-          path: codeclimate.intg-postgresql.json
+          name: codeclimate-intg-postgres
+          path: codeclimate.json
           retention-days: 1
 
   MySQL-8-Integration-Tests:
@@ -126,13 +126,13 @@ jobs:
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
           go test -coverprofile c.out ./... -tags=sql
-          ./cc-test-reporter format-coverage -o codeclimate.intg-mysql-8.json --prefix $(go list -m)
+          ./cc-test-reporter format-coverage -o codeclimate.json --prefix $(go list -m)
 
       - name: Upload Coverage Result Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: codeclimate-intg-mysql-8
-          path: codeclimate.intg-mysql-8.json
+          name: codeclimate-mysql-8
+          path: codeclimate.json
           retention-days: 1
 
 
@@ -171,13 +171,13 @@ jobs:
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
           go test -coverprofile c.out ./... -tags=sql
-          ./cc-test-reporter format-coverage -o codeclimate.intg-sql-server.json --prefix $(go list -m)
+          ./cc-test-reporter format-coverage -o codeclimate.json --prefix $(go list -m)
 
       - name: Upload Coverage Result Artifact
         uses: actions/upload-artifact@v2
         with:
           name: codeclimate-intg-sql-server
-          path: codeclimate.intg-sql-server.json
+          path: codeclimate.json
           retention-days: 1
 
   Upload-Coverage:
@@ -197,5 +197,5 @@ jobs:
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
-          ./cc-test-reporter sum-coverage */codeclimate.*.json -p 4 -o codeclimate.total.json
+          ./cc-test-reporter sum-coverage */codeclimate.json -p 4 -o codeclimate.total.json
           ./cc-test-reporter upload-coverage -i codeclimate.total.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 # yamllint disable rule:line-length
 ---
-name: tests
+name: Tests
 
 # yamllint disable-line rule:truthy
 on:
@@ -12,7 +12,7 @@ on:
       - "*"
 
 jobs:
-  tests:
+  Unit Tests:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
@@ -36,3 +36,36 @@ jobs:
       - uses: actions/setup-python@v2
       - name: Run pre commit linting
         uses: pre-commit/action@v2.0.0
+
+  PostgreSQL Integration Tests:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: iauditor_exporter_db
+          POSTGRES_USER: iauditor_exporter
+          POSTGRES_PASSWORD: iauditor_exporter
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Test & Coverage
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          TEST_DB_DIALECT: postgres
+          TEST_DB_CONN_STRING: "postgresql://iauditor_exporter:iauditor_exporter@localhost:5434/iauditor_exporter_db"
+        run: |
+          go test ./... -tags=sql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
       - "*"
 
 jobs:
-  Unit Tests:
+  Unit-Tests:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
@@ -37,9 +37,8 @@ jobs:
       - name: Run pre commit linting
         uses: pre-commit/action@v2.0.0
 
-  PostgreSQL Integration Tests:
+  PostgreSQL-Integration-Tests:
     runs-on: ubuntu-latest
-
     services:
       postgres:
         image: postgres

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,13 +3,7 @@
 name: Tests
 
 # yamllint disable-line rule:truthy
-on:
-  push:
-    branches:
-      - "*"
-  pull_request:
-    branches:
-      - "*"
+on: [push, pull_request]
 
 jobs:
   Unit-Tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 3306:3306
+          - 1433:1433
 
     steps:
       - name: Set up Go 1.x

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,14 @@ jobs:
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
           go test -coverprofile c.out ./...
-          ./cc-test-reporter after-build --prefix $(go list -m)
+          ./cc-test-reporter format-coverage -o codeclimate.unit.json --prefix $(go list -m)
+
+      - name: Upload Coverage Result
+        uses: actions/upload-artifact@v2
+        with:
+          name: codeclimate-unit
+          path: codeclimate.unit.json
+          retention-days: 1
 
       - uses: actions/setup-python@v2
       - name: Run pre commit linting

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          - 5432:5432
 
     steps:
       - name: Set up Go 1.x
@@ -65,6 +67,6 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
           TEST_DB_DIALECT: postgres
-          TEST_DB_CONN_STRING: "postgresql://iauditor_exporter:iauditor_exporter@postgres:5434/iauditor_exporter_db"
+          TEST_DB_CONN_STRING: "postgresql://iauditor_exporter:iauditor_exporter@localhost:5434/iauditor_exporter_db"
         run: |
           go test ./... -tags=sql

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ GOLANG_CROSS_VERSION  := v$(GOLANG_VERSION)
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: integration-tests
+integration-tests:
+	TEST_DB_DIALECT="postgres" TEST_DB_CONN_STRING="postgresql://iauditor_exporter:iauditor_exporter@localhost:5434/iauditor_exporter_db" go test ./... -tags=sql
+	TEST_DB_DIALECT="mysql" TEST_DB_CONN_STRING="root:iauditor_exporter@tcp(localhost:3308)/iauditor_exporter_db?charset=utf8mb4&parseTime=True&loc=Local" go test ./... -tags=sql
+	TEST_DB_DIALECT="sqlserver" TEST_DB_CONN_STRING="sqlserver://sa:iAuditorExporter12345@localhost:1433?database=master" go test ./... -tags=sql
+
 .PHONY: release-snapshot
 release-snapshot:
 	docker run \

--- a/README.md
+++ b/README.md
@@ -85,3 +85,15 @@ See above for the exact usage and alternative mechanisms to set them.
 ## Exporting
 
 See [docs/iauditor-exporter_sql.md](docs/iauditor-exporter_sql.md) and [docs/iauditor-exporter_csv.md](docs/iauditor-exporter_csv.md) for usage of specific exporters.
+
+## Development
+
+To develop `iauditor-exporter` you just need the latest version of Golang which you can grab here: [https://golang.org/doc/install](https://golang.org/doc/install).
+
+### Testing
+
+Locally you can run `go test ./...`, this will run all of the Unit tests and Integration tests that can be run without an external DB.
+
+SQL Database integration tests can be run by starting the SQL DBs `docker-compose up -d` and then running `make integration-tests`.
+
+Note: these tests will be automatically when pushing or opening a pull request against the repository.

--- a/cmd/iauditor-exporter/cmd/export/export.go
+++ b/cmd/iauditor-exporter/cmd/export/export.go
@@ -61,7 +61,7 @@ func getAPIClient() api.APIClient {
 func runSQL(cmd *cobra.Command, args []string) error {
 	apiClient := getAPIClient()
 
-	exporter, err := feed.NewSQLExporter(viper.GetString("db.dialect"), viper.GetString("db.connection_string"))
+	exporter, err := feed.NewSQLExporter(viper.GetString("db.dialect"), viper.GetString("db.connection_string"), true)
 	util.Check(err, "unable to create exporter")
 
 	return feed.ExportFeeds(viper.GetViper(), apiClient, exporter)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,19 +3,19 @@ services:
   postgres:
     image: postgres
     environment:
-      - POSTGRES_DB=iauditor_exporter_db
-      - POSTGRES_USER=iauditor_exporter
-      - POSTGRES_PASSWORD=iauditor_exporter
+      POSTGRES_DB: iauditor_exporter_db
+      POSTGRES_USER: iauditor_exporter
+      POSTGRES_PASSWORD: iauditor_exporter
     ports:
       - 5434:5432
 
   mysql:
     image: mysql:8
     environment:
-      - MYSQL_ROOT_PASSWORD=iauditor_exporter
-      - MYSQL_DATABASE=iauditor_exporter_db
-      - MYSQL_USER=iauditor_exporter
-      - MYSQL_PASSWORD=iauditor_exporter
+      MYSQL_ROOT_PASSWORD: iauditor_exporter
+      MYSQL_DATABASE: iauditor_exporter_db
+      MYSQL_USER: iauditor_exporter
+      MYSQL_PASSWORD: iauditor_exporter
     ports:
       - 3308:3306
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.8"
+services:
+  postgres:
+    image: postgres
+    environment:
+      - POSTGRES_DB=iauditor_exporter_db
+      - POSTGRES_USER=iauditor_exporter
+      - POSTGRES_PASSWORD=iauditor_exporter
+    ports:
+      - 5434:5432
+
+  mysql:
+    image: mysql:8
+    environment:
+      - MYSQL_ROOT_PASSWORD=iauditor_exporter
+      - MYSQL_DATABASE=iauditor_exporter_db
+      - MYSQL_USER=iauditor_exporter
+      - MYSQL_PASSWORD=iauditor_exporter
+    ports:
+      - 3308:3306
+
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server
+    environment:
+      SA_PASSWORD: "iAuditorExporter12345"
+      ACCEPT_EULA: "Y"
+    ports:
+      - 1433:1433

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 version: "3.8"
 services:
   postgres:

--- a/internal/app/feed/export_feeds_test.go
+++ b/internal/app/feed/export_feeds_test.go
@@ -64,6 +64,7 @@ func TestExportFeeds_should_perform_incremental_update_on_second_run(t *testing.
 	assert.Nil(t, err)
 
 	viperConfig := viper.New()
+	viperConfig.Set("export.inspection.incremental", true)
 
 	apiClient := api.NewAPIClient("http://localhost:9999", "token")
 	initMockFeedsSet1(apiClient.HTTPClient())

--- a/internal/app/feed/exporter_csv.go
+++ b/internal/app/feed/exporter_csv.go
@@ -62,7 +62,7 @@ func (e *CSVExporter) FinaliseExport(feed Feed, rows interface{}) error {
 }
 
 func NewCSVExporter(exportPath string) (*CSVExporter, error) {
-	sqlExporter, err := NewSQLExporter("sqlite", filepath.Join(exportPath, "sqlite.db"))
+	sqlExporter, err := NewSQLExporter("sqlite", filepath.Join(exportPath, "sqlite.db"), true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/feed/exporter_sql_intg_test.go
+++ b/internal/app/feed/exporter_sql_intg_test.go
@@ -1,0 +1,100 @@
+// +build sql
+
+package feed_test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/SafetyCulture/iauditor-exporter/internal/app/feed"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// getTestingSQLExporter creates a temporary DB on the target SQL Database
+func getTestingSQLExporter() (*feed.SQLExporter, error) {
+	dialect := os.Getenv("TEST_DB_DIALECT")
+	connectionString := os.Getenv("TEST_DB_CONN_STRING")
+
+	fmt.Println(connectionString)
+	exporter, err := feed.NewSQLExporter(dialect, connectionString, true)
+	if err != nil {
+		return nil, err
+	}
+
+	dbName := strings.ReplaceAll(fmt.Sprintf("iaud_exporter_%s", uuid.Must(uuid.NewV4()).String()), "-", "")
+
+	switch dialect {
+	case "postgres":
+		dbResp := exporter.DB.Exec(fmt.Sprintf("CREATE DATABASE %s", dbName))
+		err = dbResp.Error
+		break
+	case "mysql":
+		dbResp := exporter.DB.Exec(fmt.Sprintf(`CREATE DATABASE %s;`, dbName))
+		err = dbResp.Error
+		break
+	case "sqlserver":
+		dbResp := exporter.DB.Exec(fmt.Sprintf(`CREATE DATABASE %s;`, dbName))
+		err = dbResp.Error
+		break
+	default:
+		return nil, fmt.Errorf("Invalid DB dialect %s", dialect)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	connectionString = strings.Replace(connectionString, "iauditor_exporter_db", dbName, 1)
+	connectionString = strings.Replace(connectionString, "master", dbName, 1)
+
+	return feed.NewSQLExporter(dialect, connectionString, true)
+}
+
+func TestIntegrationDbExportFeeds_integration_should_not_initialise_schemas_with_auto_migrate_disabled(t *testing.T) {
+	exporter, err := getTestingSQLExporter()
+	assert.Nil(t, err)
+	exporter.AutoMigrate = false
+
+	userFeed := &feed.UserFeed{}
+
+	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
+		Truncate: false,
+	})
+	assert.Nil(t, err)
+
+	users := []feed.User{
+		{
+			ID:        "user_1",
+			Firstname: "User One",
+			Lastname:  "User One",
+		},
+	}
+
+	err = exporter.WriteRows(userFeed, users)
+	assert.NotNil(t, err, "Should throw an error when attempting to insert to a table that doesn't exist")
+}
+
+func TestIntegrationDbExportFeeds_integration_should_initialise_schemas(t *testing.T) {
+	exporter, err := getTestingSQLExporter()
+	assert.Nil(t, err)
+
+	userFeed := &feed.UserFeed{}
+
+	err = exporter.InitFeed(userFeed, &feed.InitFeedOptions{
+		Truncate: false,
+	})
+	assert.Nil(t, err)
+
+	users := []feed.User{
+		{
+			ID:        "user_1",
+			Firstname: "User One",
+			Lastname:  "User One",
+		},
+	}
+
+	err = exporter.WriteRows(userFeed, users)
+	assert.Nil(t, err)
+}

--- a/internal/app/feed/exporter_sql_test.go
+++ b/internal/app/feed/exporter_sql_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func getInmemorySQLExporter() (*feed.SQLExporter, error) {
-	return feed.NewSQLExporter("sqlite", "file::memory:")
+	return feed.NewSQLExporter("sqlite", "file::memory:", true)
 }
 
 func TestSQLExporterSupportsUpsert_should_return_true(t *testing.T) {
@@ -231,20 +231,20 @@ func TestSQLExporterLastModifiedAt_should_return_latest_modified_at(t *testing.T
 }
 
 func TestNewSQLExporter_should_create_exporter_for_sqlite(t *testing.T) {
-	sqlExporter, err := feed.NewSQLExporter("sqlite", "file::memory:")
+	sqlExporter, err := feed.NewSQLExporter("sqlite", "file::memory:", true)
 	assert.Nil(t, err)
 
 	assert.NotNil(t, sqlExporter)
 }
 
 func TestNewSQLExporter_should_return_error_for_invalid_dialect(t *testing.T) {
-	sqlExporter, err := feed.NewSQLExporter("not-supported", "file::memory:")
+	sqlExporter, err := feed.NewSQLExporter("not-supported", "file::memory:", true)
 	assert.NotNil(t, err)
 	assert.Nil(t, sqlExporter)
 }
 
 func TestNewSQLExporter_should_return_error_for_connection_errors(t *testing.T) {
-	sqlExporter, err := feed.NewSQLExporter("sqlite", "*$////bad connection string")
+	sqlExporter, err := feed.NewSQLExporter("sqlite", "*$////bad connection string", true)
 	assert.NotNil(t, err)
 	assert.Nil(t, sqlExporter)
 }


### PR DESCRIPTION
This PR adds integration tests that run against the 3 support SQL Databases for iAuditor Exporter. 
The test suite is extremely basic at the moment and will be expanded in a subsequent PR.

Also added a section in the README to run the tests locally.