### PR TITLE
[INTG-1521] Add integration tests for SQL databases

### DIFF
--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net"
@@ -87,7 +86,6 @@ func OptSetTimeout(t time.Duration) Opt {
 func OptSetProxy(proxyURL *url.URL) Opt {
 	return func(a *apiClient) {
 		a.httpTransport.Proxy = http.ProxyURL(proxyURL)
-		fmt.Println(a.httpTransport)
 	}
 }
 

--- a/internal/app/feed/exporter_csv_test.go
+++ b/internal/app/feed/exporter_csv_test.go
@@ -1,11 +1,8 @@
 package feed_test
 
 import (
-	"fmt"
 	"io/ioutil"
-	"log"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -13,17 +10,6 @@ import (
 	"github.com/SafetyCulture/iauditor-exporter/internal/app/feed"
 	"github.com/stretchr/testify/assert"
 )
-
-var dateRegex = regexp.MustCompile(`(?m)(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(\+|Z)(2[0-3]|[01][0-9])?:?([0-5][0-9])?`)
-
-func getTemporaryCSVExporter() (*feed.CSVExporter, error) {
-	dir, err := ioutil.TempDir("", "export")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return feed.NewCSVExporter(dir)
-}
 
 func TestCSVExporterSupportsUpsert_should_return_true(t *testing.T) {
 	exporter, err := getTemporaryCSVExporter()
@@ -193,8 +179,6 @@ func TestCSVExporterWriteRows_should_update_rows(t *testing.T) {
 	rows := []feed.User{}
 	resp := exporter.DB.Table("users").Scan(&rows)
 	assert.Nil(t, resp.Error)
-
-	fmt.Println(rows)
 
 	assert.Equal(t, 1, len(rows))
 	assert.Equal(t, "user_1", rows[0].ID)

--- a/internal/app/feed/exporter_sql_intg_test.go
+++ b/internal/app/feed/exporter_sql_intg_test.go
@@ -3,56 +3,13 @@
 package feed_test
 
 import (
-	"fmt"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/SafetyCulture/iauditor-exporter/internal/app/feed"
-	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
-// getTestingSQLExporter creates a temporary DB on the target SQL Database
-func getTestingSQLExporter() (*feed.SQLExporter, error) {
-	dialect := os.Getenv("TEST_DB_DIALECT")
-	connectionString := os.Getenv("TEST_DB_CONN_STRING")
-
-	fmt.Println(connectionString)
-	exporter, err := feed.NewSQLExporter(dialect, connectionString, true)
-	if err != nil {
-		return nil, err
-	}
-
-	dbName := strings.ReplaceAll(fmt.Sprintf("iaud_exporter_%s", uuid.Must(uuid.NewV4()).String()), "-", "")
-
-	switch dialect {
-	case "postgres":
-		dbResp := exporter.DB.Exec(fmt.Sprintf("CREATE DATABASE %s", dbName))
-		err = dbResp.Error
-		break
-	case "mysql":
-		dbResp := exporter.DB.Exec(fmt.Sprintf(`CREATE DATABASE %s;`, dbName))
-		err = dbResp.Error
-		break
-	case "sqlserver":
-		dbResp := exporter.DB.Exec(fmt.Sprintf(`CREATE DATABASE %s;`, dbName))
-		err = dbResp.Error
-		break
-	default:
-		return nil, fmt.Errorf("Invalid DB dialect %s", dialect)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	connectionString = strings.Replace(connectionString, "iauditor_exporter_db", dbName, 1)
-	connectionString = strings.Replace(connectionString, "master", dbName, 1)
-
-	return feed.NewSQLExporter(dialect, connectionString, true)
-}
-
-func TestIntegrationDbExportFeeds_integration_should_not_initialise_schemas_with_auto_migrate_disabled(t *testing.T) {
+func TestIntegrationDbSQLExporterInitFeed_integration_should_not_initialise_schemas_with_auto_migrate_disabled(t *testing.T) {
 	exporter, err := getTestingSQLExporter()
 	assert.Nil(t, err)
 	exporter.AutoMigrate = false
@@ -76,7 +33,7 @@ func TestIntegrationDbExportFeeds_integration_should_not_initialise_schemas_with
 	assert.NotNil(t, err, "Should throw an error when attempting to insert to a table that doesn't exist")
 }
 
-func TestIntegrationDbExportFeeds_integration_should_initialise_schemas(t *testing.T) {
+func TestIntegrationDbSQLExporterInitFeed_integration_should_initialise_schemas(t *testing.T) {
 	exporter, err := getTestingSQLExporter()
 	assert.Nil(t, err)
 

--- a/internal/app/feed/exporter_sql_test.go
+++ b/internal/app/feed/exporter_sql_test.go
@@ -1,17 +1,12 @@
 package feed_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/SafetyCulture/iauditor-exporter/internal/app/feed"
 	"github.com/stretchr/testify/assert"
 )
-
-func getInmemorySQLExporter() (*feed.SQLExporter, error) {
-	return feed.NewSQLExporter("sqlite", "file::memory:", true)
-}
 
 func TestSQLExporterSupportsUpsert_should_return_true(t *testing.T) {
 	exporter, err := getInmemorySQLExporter()
@@ -181,8 +176,6 @@ func TestSQLExporterWriteRows_should_update_rows(t *testing.T) {
 	rows := []feed.User{}
 	resp := exporter.DB.Table("users").Scan(&rows)
 	assert.Nil(t, resp.Error)
-
-	fmt.Println(rows)
 
 	assert.Equal(t, 1, len(rows))
 	assert.Equal(t, "user_1", rows[0].ID)

--- a/internal/app/feed/feed_inspection_test.go
+++ b/internal/app/feed/feed_inspection_test.go
@@ -2,7 +2,6 @@ package feed_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/SafetyCulture/iauditor-exporter/internal/app/feed"
@@ -28,14 +27,11 @@ func TestInspectionFeedExport_should_export_rows_to_sql_db(t *testing.T) {
 	}
 
 	err = inspectionsFeed.Export(context.Background(), apiClient, exporter)
-	fmt.Println(err)
 	assert.Nil(t, err)
 
 	rows := []feed.Inspection{}
 	resp := exporter.DB.Table("inspections").Scan(&rows)
 	assert.Nil(t, resp.Error)
-
-	fmt.Println(rows)
 
 	assert.Equal(t, 3, len(rows))
 	assert.Equal(t, "audit_1", rows[0].ID)

--- a/internal/app/feed/utils_test.go
+++ b/internal/app/feed/utils_test.go
@@ -1,0 +1,102 @@
+package feed_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/SafetyCulture/iauditor-exporter/internal/app/feed"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+var dateRegex = regexp.MustCompile(`(?m)(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(\+|Z)(2[0-3]|[01][0-9])?:?([0-5][0-9])?`)
+
+// getInmemorySQLExporter creates a SQLExporter that uses an inmemory DB
+func getInmemorySQLExporter() (*feed.SQLExporter, error) {
+	return feed.NewSQLExporter("sqlite", "file::memory:", true)
+}
+
+// getTemporaryCSVExporter creates a CSVExporter that writes to a temp folder
+func getTemporaryCSVExporter() (*feed.CSVExporter, error) {
+	dir, err := ioutil.TempDir("", "export")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return feed.NewCSVExporter(dir)
+}
+
+// getTemporaryCSVExporterWithRealSQLExporter creates a CSV exporter that writes a temporary folder
+// but also uses a real DB as an intermediary
+func getTemporaryCSVExporterWithRealSQLExporter(sqlExporter *feed.SQLExporter) (*feed.CSVExporter, error) {
+	dir, err := ioutil.TempDir("", "export")
+	if err != nil {
+		return nil, err
+	}
+
+	exporter, err := feed.NewCSVExporter(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	exporter.SQLExporter = sqlExporter
+
+	return exporter, err
+}
+
+// getTestingSQLExporter creates a temporary DB on the target SQL Database
+func getTestingSQLExporter() (*feed.SQLExporter, error) {
+	dialect := os.Getenv("TEST_DB_DIALECT")
+	connectionString := os.Getenv("TEST_DB_CONN_STRING")
+
+	exporter, err := feed.NewSQLExporter(dialect, connectionString, true)
+	if err != nil {
+		return nil, err
+	}
+
+	dbName := strings.ReplaceAll(fmt.Sprintf("iaud_exporter_%s", uuid.Must(uuid.NewV4()).String()), "-", "")
+
+	switch dialect {
+	case "postgres":
+		dbResp := exporter.DB.Exec(fmt.Sprintf("CREATE DATABASE %s", dbName))
+		err = dbResp.Error
+		break
+	case "mysql":
+		dbResp := exporter.DB.Exec(fmt.Sprintf(`CREATE DATABASE %s;`, dbName))
+		err = dbResp.Error
+		break
+	case "sqlserver":
+		dbResp := exporter.DB.Exec(fmt.Sprintf(`CREATE DATABASE %s;`, dbName))
+		err = dbResp.Error
+		break
+	default:
+		return nil, fmt.Errorf("Invalid DB dialect %s", dialect)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	connectionString = strings.Replace(connectionString, "iauditor_exporter_db", dbName, 1)
+	connectionString = strings.Replace(connectionString, "master", dbName, 1)
+
+	return feed.NewSQLExporter(dialect, connectionString, true)
+}
+
+// filesEqualish checks if files are equal enough (ignoring dates)
+func filesEqualish(t *testing.T, expectedPath, actualPath string) {
+	expectedFile, err := ioutil.ReadFile(expectedPath)
+	assert.Nil(t, err)
+
+	actualFile, err := ioutil.ReadFile(actualPath)
+	assert.Nil(t, err)
+
+	assert.Equal(t,
+		dateRegex.ReplaceAllLiteralString(strings.TrimSpace(string(expectedFile)), "--date--"),
+		dateRegex.ReplaceAllLiteralString(strings.TrimSpace(string(actualFile)), "--date--"),
+	)
+}


### PR DESCRIPTION
This PR adds integration tests for SQL databases. You might notice that these look like they are testing CSV exporting... Well that is because they are! These tests leverage the fact that our CSV exporter wraps our SQLExporter and uses a file based SQLite DB to perform incremental refreshes.

Instead of using that SQLite DB, we just use a real one. Simple as that, we have tested our ability to export to a SQL DB, and comparing the output is as easy as comparing 2 CSV files.

Also moves some test utils around and removes some debugging statements.