### PR TITLE
[INTG-1557] Add improved handling of different Database parameter limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,13 @@ integration-tests:
 	TEST_DB_DIALECT="mysql" TEST_DB_CONN_STRING="root:iauditor_exporter@tcp(localhost:3308)/iauditor_exporter_db?charset=utf8mb4&parseTime=True&loc=Local" go test ./... -tags=sql
 	TEST_DB_DIALECT="sqlserver" TEST_DB_CONN_STRING="sqlserver://sa:iAuditorExporter12345@localhost:1433?database=master" go test ./... -tags=sql
 
+.PHONY: soak-tests
+soak-tests:
+	TEST_API_HOST="https://api.safetyculture.io" TEST_DB_DIALECT="postgres" TEST_DB_CONN_STRING="postgresql://iauditor_exporter:iauditor_exporter@localhost:5434/iauditor_exporter_db" go test ./... -tags=soak
+	TEST_API_HOST="https://api.safetyculture.io" TEST_DB_DIALECT="mysql" TEST_DB_CONN_STRING="root:iauditor_exporter@tcp(localhost:3308)/iauditor_exporter_db?charset=utf8mb4&parseTime=True&loc=Local" go test ./... -tags=soak
+	TEST_API_HOST="https://api.safetyculture.io" TEST_DB_DIALECT="sqlserver" TEST_DB_CONN_STRING="sqlserver://sa:iAuditorExporter12345@localhost:1433?database=master" go test ./... -tags=soak
+	TEST_API_HOST="https://api.safetyculture.io" TEST_DB_DIALECT="sqlite" TEST_DB_CONN_STRING="file::memory:" go test ./... -tags=soak
+
 .PHONY: release-snapshot
 release-snapshot:
 	docker run \

--- a/internal/app/feed/export_feeds_soak_test.go
+++ b/internal/app/feed/export_feeds_soak_test.go
@@ -1,0 +1,30 @@
+// +build soak
+
+package feed_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/SafetyCulture/iauditor-exporter/internal/app/api"
+	"github.com/SafetyCulture/iauditor-exporter/internal/app/feed"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntegrationDbSoakExportFeeds_should_successfully_export_with_significant_data(t *testing.T) {
+	exporter, err := getTestingSQLExporter()
+	assert.Nil(t, err)
+	exporter.AutoMigrate = true
+
+	fmt.Println(err, exporter)
+
+	viperConfig := viper.New()
+
+	apiClient := api.NewAPIClient(os.Getenv("TEST_API_HOST"), os.Getenv("TEST_ACCESS_TOKEN"))
+
+	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
+	assert.Nil(t, err)
+}

--- a/internal/app/feed/exporter_sql.go
+++ b/internal/app/feed/exporter_sql.go
@@ -27,6 +27,19 @@ func (e *SQLExporter) SupportsUpsert() bool {
 	return true
 }
 
+// ParameterLimit returns the number of parameters supported by the target DB
+func (e *SQLExporter) ParameterLimit() int {
+	switch e.DB.Dialector.Name() {
+	case "sqlserver":
+		return 2100
+	case "sqlite":
+		return 32768
+	}
+
+	return 65536
+}
+
+// CreateSchema creates the schema on the DB for the supplied feed
 func (e *SQLExporter) CreateSchema(feed Feed, rows interface{}) error {
 	return e.InitFeed(feed, &InitFeedOptions{
 		Truncate: false,
@@ -52,11 +65,6 @@ func (e *SQLExporter) InitFeed(feed Feed, opts *InitFeedOptions) error {
 		}
 	}
 
-	return nil
-}
-
-// SetLastModifiedAt updates the last modified at for the feed. No op for SQL as this is managed automatically.
-func (e *SQLExporter) SetLastModifiedAt(feed Feed, ts time.Time) error {
 	return nil
 }
 

--- a/internal/app/feed/feed.go
+++ b/internal/app/feed/feed.go
@@ -27,15 +27,12 @@ type InitFeedOptions struct {
 // Exporter is an interface to a Feed exporter. It provides methods to write rows out to a implemented format
 type Exporter interface {
 	InitFeed(feed Feed, opts *InitFeedOptions) error
-
-	WriteRows(feed Feed, rows interface{}) error
-
-	FinaliseExport(feed Feed, rows interface{}) error
-
 	CreateSchema(feed Feed, rows interface{}) error
 
-	SetLastModifiedAt(feed Feed, ts time.Time) error
+	WriteRows(feed Feed, rows interface{}) error
+	FinaliseExport(feed Feed, rows interface{}) error
 	LastModifiedAt(feed Feed) (*time.Time, error)
 
 	SupportsUpsert() bool
+	ParameterLimit() int
 }

--- a/internal/app/feed/feed_group.go
+++ b/internal/app/feed/feed_group.go
@@ -47,7 +47,7 @@ func (f *GroupFeed) Order() string {
 	return "group_id"
 }
 
-// Create schema of the feed for the supplied exporter
+// CreateSchema creates the schema of the feed for the supplied exporter
 func (f *GroupFeed) CreateSchema(exporter Exporter) error {
 	return exporter.CreateSchema(f, &[]*Group{})
 }
@@ -75,8 +75,18 @@ func (f *GroupFeed) Export(ctx context.Context, apiClient api.APIClient, exporte
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			err = exporter.WriteRows(f, rows)
-			util.Check(err, "Failed to write data to exporter")
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
+
+			for i := 0; i < len(rows); i += batchSize {
+				j := i + batchSize
+				if j > len(rows) {
+					j = len(rows)
+				}
+
+				err = exporter.WriteRows(f, rows[i:j])
+				util.Check(err, "Failed to write data to exporter")
+			}
 		}
 
 		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)

--- a/internal/app/feed/feed_group_user.go
+++ b/internal/app/feed/feed_group_user.go
@@ -48,7 +48,7 @@ func (f *GroupUserFeed) Order() string {
 	return "group_id, user_id"
 }
 
-// Create schema of the feed for the supplied exporter
+// CreateSchema creates the schema of the feed for the supplied exporter
 func (f *GroupUserFeed) CreateSchema(exporter Exporter) error {
 	return exporter.CreateSchema(f, &[]*GroupUser{})
 }
@@ -76,8 +76,18 @@ func (f *GroupUserFeed) Export(ctx context.Context, apiClient api.APIClient, exp
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			err = exporter.WriteRows(f, rows)
-			util.Check(err, "Failed to write data to exporter")
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
+
+			for i := 0; i < len(rows); i += batchSize {
+				j := i + batchSize
+				if j > len(rows) {
+					j = len(rows)
+				}
+
+				err = exporter.WriteRows(f, rows[i:j])
+				util.Check(err, "Failed to write data to exporter")
+			}
 		}
 
 		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)

--- a/internal/app/feed/feed_inspection.go
+++ b/internal/app/feed/feed_inspection.go
@@ -109,17 +109,31 @@ func (f *InspectionFeed) writeRows(exporter Exporter, rows []*Inspection) error 
 		skipIDs[id] = true
 	}
 
-	rowsToInsert := []*Inspection{}
-	for _, row := range rows {
-		if !skipIDs[row.ID] {
-			rowsToInsert = append(rowsToInsert, row)
+	// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+	batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
+	for i := 0; i < len(rows); i += batchSize {
+		j := i + batchSize
+		if j > len(rows) {
+			j = len(rows)
 		}
+
+		// Some audits in production have the same item ID multiple times
+		// We can't insert them simultaneously. This means we are dropping data, which sucks.
+		rowsToInsert := []*Inspection{}
+		for _, row := range rows[i:j] {
+			skip := skipIDs[row.ID]
+			if !skip {
+				rowsToInsert = append(rowsToInsert, row)
+			}
+		}
+
+		return exporter.WriteRows(f, rowsToInsert)
 	}
 
-	return exporter.WriteRows(f, rowsToInsert)
+	return nil
 }
 
-// Create schema of the feed for the supplied exporter
+// CreateSchema creates the schema of the feed for the supplied exporter
 func (f *InspectionFeed) CreateSchema(exporter Exporter) error {
 	return exporter.CreateSchema(f, &[]*Inspection{})
 }
@@ -159,9 +173,6 @@ func (f *InspectionFeed) Export(ctx context.Context, apiClient api.APIClient, ex
 		if len(rows) != 0 {
 			err = f.writeRows(exporter, rows)
 			util.Check(err, "Failed to write data to exporter")
-
-			err = exporter.SetLastModifiedAt(f, rows[len(rows)-1].ModifiedAt)
-			util.Check(err, "Failed to write last modified at time")
 		}
 
 		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)

--- a/internal/app/feed/feed_inspection.go
+++ b/internal/app/feed/feed_inspection.go
@@ -35,7 +35,7 @@ type Inspection struct {
 	DocumentNo      string     `json:"document_no" csv:"document_no"`
 	PreparedBy      string     `json:"prepared_by" csv:"prepared_by"`
 	Location        string     `json:"location" csv:"location"`
-	ConductedOn     time.Time  `json:"conducted_on" csv:"conducted_on"`
+	ConductedOn     *time.Time `json:"conducted_on" csv:"conducted_on"`
 	Personnel       string     `json:"personnel" csv:"personnel"`
 	ClientSite      string     `json:"client_site" csv:"client_site"`
 }

--- a/internal/app/feed/feed_schedule.go
+++ b/internal/app/feed/feed_schedule.go
@@ -77,7 +77,7 @@ func (f *ScheduleFeed) Order() string {
 	return "schedule_id"
 }
 
-// Create schema of the feed for the supplied exporter
+// CreateSchema creates the schema of the feed for the supplied exporter
 func (f *ScheduleFeed) CreateSchema(exporter Exporter) error {
 	return exporter.CreateSchema(f, &[]*Schedule{})
 }
@@ -107,8 +107,18 @@ func (f *ScheduleFeed) Export(ctx context.Context, apiClient api.APIClient, expo
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			err = exporter.WriteRows(f, rows)
-			util.Check(err, "Failed to write data to exporter")
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
+
+			for i := 0; i < len(rows); i += batchSize {
+				j := i + batchSize
+				if j > len(rows) {
+					j = len(rows)
+				}
+
+				err = exporter.WriteRows(f, rows[i:j])
+				util.Check(err, "Failed to write data to exporter")
+			}
 		}
 
 		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)

--- a/internal/app/feed/feed_schedule_assginee.go
+++ b/internal/app/feed/feed_schedule_assginee.go
@@ -54,7 +54,7 @@ func (f *ScheduleAssigneeFeed) Order() string {
 	return "schedule_id, assignee_id"
 }
 
-// Create schema of the feed for the supplied exporter
+// CreateSchema creates the schema of the feed for the supplied exporter
 func (f *ScheduleAssigneeFeed) CreateSchema(exporter Exporter) error {
 	return exporter.CreateSchema(f, &[]*ScheduleAssignee{})
 }
@@ -83,8 +83,18 @@ func (f *ScheduleAssigneeFeed) Export(ctx context.Context, apiClient api.APIClie
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			err = exporter.WriteRows(f, rows)
-			util.Check(err, "Failed to write data to exporter")
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
+
+			for i := 0; i < len(rows); i += batchSize {
+				j := i + batchSize
+				if j > len(rows) {
+					j = len(rows)
+				}
+
+				err = exporter.WriteRows(f, rows[i:j])
+				util.Check(err, "Failed to write data to exporter")
+			}
 		}
 
 		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)

--- a/internal/app/feed/feed_schedule_occurrence.go
+++ b/internal/app/feed/feed_schedule_occurrence.go
@@ -15,7 +15,7 @@ type ScheduleOccurrence struct {
 	ScheduleID       string     `json:"schedule_id" csv:"schedule_id"`
 	OccurrenceID     string     `json:"occurrence_id" csv:"occurrence_id"`
 	TemplateID       string     `json:"template_id" csv:"template_id"`
-	MissTime         time.Time  `json:"miss_time" csv:"miss_time"`
+	MissTime         *time.Time `json:"miss_time" csv:"miss_time"`
 	OccurrenceStatus string     `json:"occurrence_status" csv:"occurrence_status"`
 	AuditID          *string    `json:"audit_id" csv:"audit_id"`
 	CompletedAt      *time.Time `json:"completed_at" csv:"completed_at"`

--- a/internal/app/feed/feed_schedule_occurrence.go
+++ b/internal/app/feed/feed_schedule_occurrence.go
@@ -64,7 +64,7 @@ func (f *ScheduleOccurrenceFeed) Order() string {
 	return "occurrence_id ASC, schedule_id"
 }
 
-// Create schema of the feed for the supplied exporter
+// CreateSchema creates the schema of the feed for the supplied exporter
 func (f *ScheduleOccurrenceFeed) CreateSchema(exporter Exporter) error {
 	return exporter.CreateSchema(f, &[]*ScheduleOccurrence{})
 }
@@ -109,8 +109,18 @@ func (f *ScheduleOccurrenceFeed) Export(ctx context.Context, apiClient api.APICl
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			err = f.writeRows(exporter, rows)
-			util.Check(err, "Failed to write data to exporter")
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
+
+			for i := 0; i < len(rows); i += batchSize {
+				j := i + batchSize
+				if j > len(rows) {
+					j = len(rows)
+				}
+
+				err = exporter.WriteRows(f, rows[i:j])
+				util.Check(err, "Failed to write data to exporter")
+			}
 		}
 
 		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)

--- a/internal/app/feed/feed_site.go
+++ b/internal/app/feed/feed_site.go
@@ -51,7 +51,7 @@ func (f *SiteFeed) Order() string {
 	return "site_id"
 }
 
-// Create schema of the feed for the supplied exporter
+// CreateSchema creates the schema of the feed for the supplied exporter
 func (f *SiteFeed) CreateSchema(exporter Exporter) error {
 	return exporter.CreateSchema(f, &[]*Site{})
 }
@@ -79,8 +79,18 @@ func (f *SiteFeed) Export(ctx context.Context, apiClient api.APIClient, exporter
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			err = exporter.WriteRows(f, rows)
-			util.Check(err, "Failed to write data to exporter")
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
+
+			for i := 0; i < len(rows); i += batchSize {
+				j := i + batchSize
+				if j > len(rows) {
+					j = len(rows)
+				}
+
+				err = exporter.WriteRows(f, rows[i:j])
+				util.Check(err, "Failed to write data to exporter")
+			}
 		}
 
 		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)

--- a/internal/app/feed/feed_template.go
+++ b/internal/app/feed/feed_template.go
@@ -66,7 +66,7 @@ func (f *TemplateFeed) Order() string {
 	return "modified_at ASC, template_id"
 }
 
-// Create schema of the feed for the supplied exporter
+// CreateSchema creates the schema of the feed for the supplied exporter
 func (f *TemplateFeed) CreateSchema(exporter Exporter) error {
 	return exporter.CreateSchema(f, &[]*Template{})
 }
@@ -101,11 +101,18 @@ func (f *TemplateFeed) Export(ctx context.Context, apiClient api.APIClient, expo
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			err = exporter.WriteRows(f, rows)
-			util.Check(err, "Failed to write data to exporter")
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 
-			err = exporter.SetLastModifiedAt(f, rows[len(rows)-1].ModifiedAt)
-			util.Check(err, "Failed to write last modified at time")
+			for i := 0; i < len(rows); i += batchSize {
+				j := i + batchSize
+				if j > len(rows) {
+					j = len(rows)
+				}
+
+				err = exporter.WriteRows(f, rows[i:j])
+				util.Check(err, "Failed to write data to exporter")
+			}
 		}
 
 		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)

--- a/internal/app/feed/feed_user.go
+++ b/internal/app/feed/feed_user.go
@@ -55,7 +55,7 @@ func (f *UserFeed) Order() string {
 	return "user_id"
 }
 
-// Create schema of the feed for the supplied exporter
+// CreateSchema creates the schema of the feed for the supplied exporter
 func (f *UserFeed) CreateSchema(exporter Exporter) error {
 	return exporter.CreateSchema(f, &[]*User{})
 }
@@ -83,8 +83,18 @@ func (f *UserFeed) Export(ctx context.Context, apiClient api.APIClient, exporter
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			err = exporter.WriteRows(f, rows)
-			util.Check(err, "Failed to write data to exporter")
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
+
+			for i := 0; i < len(rows); i += batchSize {
+				j := i + batchSize
+				if j > len(rows) {
+					j = len(rows)
+				}
+
+				err = exporter.WriteRows(f, rows[i:j])
+				util.Check(err, "Failed to write data to exporter")
+			}
 		}
 
 		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)

--- a/internal/app/feed/mocks/set_1/feed_schedule_occurrences_1.json
+++ b/internal/app/feed/mocks/set_1/feed_schedule_occurrences_1.json
@@ -25,6 +25,18 @@
       "occurrence_status": "TODO",
       "audit_id": null,
       "completed_at": null,
+      "user_id": "user_2",
+      "assignee_status": "TODO"
+    },
+    {
+      "id": "scheduleitem_2_occurrence_1641027600000_user_3",
+      "schedule_id": "scheduleitem_2",
+      "occurrence_id": "occurrence_1641027600000",
+      "template_id": "template_2",
+      "miss_time": null,
+      "occurrence_status": "TODO",
+      "audit_id": null,
+      "completed_at": null,
       "user_id": "user_3",
       "assignee_status": "TODO"
     }

--- a/internal/app/feed/mocks/set_1/outputs/schedule_occurrences.csv
+++ b/internal/app/feed/mocks/set_1/outputs/schedule_occurrences.csv
@@ -1,3 +1,4 @@
 id,schedule_id,occurrence_id,template_id,miss_time,occurrence_status,audit_id,completed_at,exported_at,user_id,assignee_status
-scheduleitem_1_occurrence_1641027600000_user_1,scheduleitem_1,occurrence_1641027600000,template_1,2023-01-01T01:00:00Z,TODO,,,2020-11-06T08:21:16.196018+11:00,user_1,TODO
-scheduleitem_2_occurrence_1641027600000_user_2,scheduleitem_2,occurrence_1641027600000,template_2,2023-01-01T01:00:00Z,TODO,,,2020-11-06T08:21:16.196018+11:00,user_3,TODO
+scheduleitem_1_occurrence_1641027600000_user_1,scheduleitem_1,occurrence_1641027600000,template_1,--date--,TODO,,,--date--,user_1,TODO
+scheduleitem_2_occurrence_1641027600000_user_2,scheduleitem_2,occurrence_1641027600000,template_2,--date--,TODO,,,--date--,user_2,TODO
+scheduleitem_2_occurrence_1641027600000_user_3,scheduleitem_2,occurrence_1641027600000,template_2,,TODO,,,--date--,user_3,TODO

--- a/internal/app/feed/mocks/set_2/outputs/schedule_occurrences.csv
+++ b/internal/app/feed/mocks/set_2/outputs/schedule_occurrences.csv
@@ -1,3 +1,4 @@
 id,schedule_id,occurrence_id,template_id,miss_time,occurrence_status,audit_id,completed_at,exported_at,user_id,assignee_status
-scheduleitem_1_occurrence_1641027600000_user_1,scheduleitem_1,occurrence_1641027600000,template_1,2023-01-01T01:00:00Z,TODO,,,2020-11-06T08:21:16.196018+11:00,user_1,TODO
-scheduleitem_2_occurrence_1641027600000_user_2,scheduleitem_2,occurrence_1641027600000,template_2,2023-01-01T01:00:00Z,TODO,,,2020-11-06T08:21:16.196018+11:00,user_3,TODO
+scheduleitem_1_occurrence_1641027600000_user_1,scheduleitem_1,occurrence_1641027600000,template_1,--date--,TODO,,,--date--,user_1,TODO
+scheduleitem_2_occurrence_1641027600000_user_2,scheduleitem_2,occurrence_1641027600000,template_2,--date--,TODO,,,--date--,user_2,TODO
+scheduleitem_2_occurrence_1641027600000_user_3,scheduleitem_2,occurrence_1641027600000,template_2,,TODO,,,--date--,user_3,TODO

--- a/internal/app/feed/utils_test.go
+++ b/internal/app/feed/utils_test.go
@@ -62,9 +62,7 @@ func getTestingSQLExporter() (*feed.SQLExporter, error) {
 	dbName := strings.ReplaceAll(fmt.Sprintf("iaud_exporter_%s", uuid.Must(uuid.NewV4()).String()), "-", "")
 
 	switch dialect {
-	case "postgres":
-	case "mysql":
-	case "sqlserver":
+	case "postgres", "mysql", "sqlserver":
 		dbResp := exporter.DB.Exec(fmt.Sprintf(`CREATE DATABASE %s;`, dbName))
 		err = dbResp.Error
 		break

--- a/internal/app/feed/utils_test.go
+++ b/internal/app/feed/utils_test.go
@@ -63,17 +63,13 @@ func getTestingSQLExporter() (*feed.SQLExporter, error) {
 
 	switch dialect {
 	case "postgres":
-		dbResp := exporter.DB.Exec(fmt.Sprintf("CREATE DATABASE %s", dbName))
-		err = dbResp.Error
-		break
 	case "mysql":
-		dbResp := exporter.DB.Exec(fmt.Sprintf(`CREATE DATABASE %s;`, dbName))
-		err = dbResp.Error
-		break
 	case "sqlserver":
 		dbResp := exporter.DB.Exec(fmt.Sprintf(`CREATE DATABASE %s;`, dbName))
 		err = dbResp.Error
 		break
+	case "sqlite":
+		return exporter, nil
 	default:
 		return nil, fmt.Errorf("Invalid DB dialect %s", dialect)
 	}


### PR DESCRIPTION
Different databases have different limits on the number of parameters they can support in a single query.

Feeds now use this to calculate the number of rows they can insert in any given query.