### PR TITLE
INTG-1551: clean up config command

### DIFF
--- a/cmd/iauditor-exporter/cmd/configure/configure.go
+++ b/cmd/iauditor-exporter/cmd/configure/configure.go
@@ -1,6 +1,7 @@
 package configure
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/SafetyCulture/iauditor-exporter/internal/app/util"
@@ -15,13 +16,25 @@ func Cmd() *cobra.Command {
 		Short: "Initialises your configuration file.",
 		Long:  `Initialises your config file with your access token and other configuration options.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			logger := util.GetLogger()
+			_, err := os.Stat(viper.ConfigFileUsed())
+			configNoExists := os.IsNotExist(err)
+			if configNoExists {
+				fmt.Println("Creating a new config file:", viper.ConfigFileUsed())
+			} else {
+				fmt.Println("Config file found:", viper.ConfigFileUsed())
+			}
 
 			// TODO - Validate flags shouldn't be empty.
 			// TODO - Optionally accept the flags as a prompt.
 			util.Check(viper.WriteConfigAs(viper.ConfigFileUsed()), "while writing viper config to file")
 
-			logger.Infof("Updating config file: %s", viper.ConfigFileUsed())
+			if configNoExists {
+				fmt.Println("Config file created successfully \U0001f389")
+			} else {
+				fmt.Println("Config file updated successfully \U0001f389")
+			}
+
+			fmt.Println("\nVisit \"https://github.com/SafetyCulture/iauditor-exporter#configure\" to learn more about configuration options.")
 
 			util.Check(os.Chmod(viper.ConfigFileUsed(), 0666), "while updating file permissions")
 		},

--- a/cmd/iauditor-exporter/cmd/root.go
+++ b/cmd/iauditor-exporter/cmd/root.go
@@ -78,6 +78,7 @@ func init() {
 	addCmd(export.CSVCmd(), connectionFlags, csvFlags, inspectionFlags, templatesFlag, tablesFlag, schemasFlag)
 	addCmd(export.InspectionJSONCmd(), connectionFlags, inspectionFlags, templatesFlag)
 	addCmd(export.PrintSchemaCmd())
+	addCmd(configure.Cmd(), connectionFlags, dbFlags, csvFlags, inspectionFlags, templatesFlag, tablesFlag)
 	RootCmd.AddCommand(configure.Cmd())
 	RootCmd.AddCommand(&cobra.Command{
 		Hidden: true,


### PR DESCRIPTION
These changes will make it more clear when the config file is being created or updated.

Creating a new config file:
![image](https://user-images.githubusercontent.com/2681258/103955258-0673d500-519a-11eb-92e9-43e35a041bd8.png)

When config file exists:
![image](https://user-images.githubusercontent.com/2681258/103955393-45a22600-519a-11eb-91a5-07206d4d68ac.png)

I also spent some time trying to add comments to the config file. This is not a trivial task. Config file is created by `viper` and it doesn't support comments at the moment. One option is to make changes to viper and add support for comments. But this is going to be a big overtaking due to the fact that viper supports many configuration formats (yaml, json and ...).
Another option is to have an example file with all the comments and copy that. This has a few downsides:
- Viper won't create/update the config
- Users cannot update the config file using command line flags anymore
- If flags are created/updated we have to make sure those changes are reflected in the config sample 

I decided at this stage it would be better to show a message and send users to the documentation. 