### PR TITLE
INTG-1566: add commit message prefix to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       interval: "daily"
       #  Check for npm updates at 11PM UTC, 9AM AEST, 10AM AEDT
       time: "23:00"
+    commit-message:
+      prefix: "[INTG-1601]"


### PR DESCRIPTION
Added commit message prefix to `dependabot.yml `. This will fix `SafetyTravis` error message for not having a Jira ticket.