### PR TITLE
INTG-1614: remov duplicate configure command

### DIFF
--- a/cmd/iauditor-exporter/cmd/root.go
+++ b/cmd/iauditor-exporter/cmd/root.go
@@ -80,7 +80,6 @@ func init() {
 	addCmd(export.ReportCmd(), connectionFlags, pathFlag, inspectionFlags, templatesFlag, reportFlags)
 	addCmd(export.PrintSchemaCmd())
 	addCmd(configure.Cmd(), connectionFlags, dbFlags, pathFlag, inspectionFlags, templatesFlag, tablesFlag)
-	RootCmd.AddCommand(configure.Cmd())
 	RootCmd.AddCommand(&cobra.Command{
 		Hidden: true,
 		Use:    "docs",


### PR DESCRIPTION
`configure` command was added to the list of commands twice. This will remove one instance.