### PR TITLE
[INTG-1618] Fix exporting breaking when performing incremental exports against SQL Server

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Trufflehog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Trufflehog:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -4,6 +4,7 @@ name: Security Scan
 
 # yamllint disable-line rule:truthy
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened]
   push:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Unit-Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ name: Tests
 
 # yamllint disable-line rule:truthy
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened]
   push:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Unit-Tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
       - id: forbid-binary
         exclude: docs/assets/.*
       - id: git-check
+      - id: shellcheck
       - id: shfmt
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.20.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,6 @@ repos:
       - id: forbid-binary
         exclude: docs/assets/.*
       - id: git-check
-      - id: shellcheck
       - id: shfmt
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.20.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,6 @@ repos:
       - id: forbid-binary
         exclude: docs/assets/.*
       - id: git-check
-      - id: shellcheck
-      - id: shfmt
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.20.0
     hooks:

--- a/internal/app/feed/exporter_sql.go
+++ b/internal/app/feed/exporter_sql.go
@@ -93,6 +93,8 @@ func (e *SQLExporter) WriteRows(feed Feed, rows interface{}) error {
 }
 
 type modifiedAtRow struct {
+	// ExportedAt is here so gorm has an additional field to sort on in SQL Server
+	ExportedAt time.Time
 	ModifiedAt time.Time
 }
 
@@ -100,7 +102,7 @@ type modifiedAtRow struct {
 func (e *SQLExporter) LastModifiedAt(feed Feed) (*time.Time, error) {
 	latestRow := modifiedAtRow{}
 
-	result := e.DB.Table(feed.Name()).Order("modified_at desc").Limit(1).First(&latestRow)
+	result := e.DB.Table(feed.Name()).Order("modified_at DESC").Limit(1).First(&latestRow)
 	if result.RowsAffected != 0 {
 		return &latestRow.ModifiedAt, nil
 	}

--- a/internal/app/feed/exporter_sql_intg_test.go
+++ b/internal/app/feed/exporter_sql_intg_test.go
@@ -4,10 +4,67 @@ package feed_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/SafetyCulture/iauditor-exporter/internal/app/feed"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestIntegrationDbSQLExporterLastModifiedAt_should_return_latest_modified_at(t *testing.T) {
+	exporter, err := getTestingSQLExporter()
+	assert.Nil(t, err)
+
+	inspectionFeed := &feed.InspectionFeed{}
+
+	err = exporter.InitFeed(inspectionFeed, &feed.InitFeedOptions{
+		Truncate: false,
+	})
+	assert.Nil(t, err)
+
+	now := time.Now()
+	inspections := []feed.Inspection{
+		{
+			ID:           "audit_1",
+			DateStarted:  now,
+			DateModified: now,
+			CreatedAt:    now,
+			ExportedAt:   now,
+			ModifiedAt:   now,
+		},
+		{
+			ID:           "audit_2",
+			DateStarted:  time.Now().Add(time.Hour * -128),
+			DateModified: time.Now().Add(time.Hour * -128),
+			CreatedAt:    time.Now().Add(time.Hour * -128),
+			ExportedAt:   time.Now().Add(time.Hour * -128),
+			ModifiedAt:   time.Now().Add(time.Hour * -128),
+		},
+		{
+			ID:           "audit_3",
+			DateStarted:  time.Now().Add(time.Hour * -3000),
+			DateModified: time.Now().Add(time.Hour * -3000),
+			CreatedAt:    time.Now().Add(time.Hour * -3000),
+			ExportedAt:   time.Now().Add(time.Hour * -3000),
+			ModifiedAt:   time.Now().Add(time.Hour * -3000),
+		},
+		{
+			ID:           "audit_4",
+			DateStarted:  time.Now().Add(time.Hour * -2),
+			DateModified: time.Now().Add(time.Hour * -2),
+			CreatedAt:    time.Now().Add(time.Hour * -2),
+			ExportedAt:   time.Now().Add(time.Hour * -2),
+			ModifiedAt:   time.Now().Add(time.Hour * -2),
+		},
+	}
+
+	err = exporter.WriteRows(inspectionFeed, inspections)
+	assert.Nil(t, err)
+
+	lastModifiedAt, err := exporter.LastModifiedAt(inspectionFeed)
+	assert.Nil(t, err)
+	// Times are slightly lossy, convery to ISO string
+	assert.Equal(t, now.Format(time.RFC3339), lastModifiedAt.Format(time.RFC3339))
+}
 
 func TestIntegrationDbSQLExporterInitFeed_integration_should_not_initialise_schemas_with_auto_migrate_disabled(t *testing.T) {
 	exporter, err := getTestingSQLExporter()


### PR DESCRIPTION
It looks like gorm is adding a default sort by the primary key to all queries. It thinks that ModifiedAt is the primary key as it is the only one present in the model.

Adding ExportedAt first makes this the default sort. It was chosen as it is present on all tables.