### PR TITLE
[INTG-1636] Inspection json export ignoring last modified timestamp

### DIFF
--- a/internal/app/exporter/exporter_json_test.go
+++ b/internal/app/exporter/exporter_json_test.go
@@ -3,6 +3,8 @@ package exporter_test
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"testing"
 	"time"
 
@@ -49,13 +51,17 @@ func TestLastModifiedAt(t *testing.T) {
 }
 
 func TestLastModifiedAtAfterRestart(t *testing.T) {
-	tmpExporter := getTemporaryJSONExporter()
+	dir, err := ioutil.TempDir("", "export")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tmpExporter1 := exporter.NewJSONExporter(dir)
 	now := time.Now()
-	tmpExporter.SetLastModifiedAt(now)
+	tmpExporter1.SetLastModifiedAt(now)
 
-	exporter.SetLastModifiedFile(nil)
-
-	lastModified := tmpExporter.GetLastModifiedAt()
+	tmpExporter2 := exporter.NewJSONExporter(dir)
+	lastModified := tmpExporter2.GetLastModifiedAt()
 	assert.NotNil(t, lastModified)
 
 	expected := fmt.Sprintf("%d-%02d-%02dT%02d:%02d:%02d",

--- a/internal/app/exporter/exporter_json_test.go
+++ b/internal/app/exporter/exporter_json_test.go
@@ -48,6 +48,25 @@ func TestLastModifiedAt(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestLastModifiedAtAfterRestart(t *testing.T) {
+	tmpExporter := getTemporaryJSONExporter()
+	now := time.Now()
+	tmpExporter.SetLastModifiedAt(now)
+
+	exporter.SetLastModifiedFile(nil)
+
+	lastModified := tmpExporter.GetLastModifiedAt()
+	assert.NotNil(t, lastModified)
+
+	expected := fmt.Sprintf("%d-%02d-%02dT%02d:%02d:%02d",
+		now.Year(), now.Month(), now.Day(),
+		now.Hour(), now.Minute(), now.Second())
+	actual := fmt.Sprintf("%d-%02d-%02dT%02d:%02d:%02d",
+		lastModified.Year(), lastModified.Month(), lastModified.Day(),
+		lastModified.Hour(), lastModified.Minute(), lastModified.Second())
+	assert.Equal(t, expected, actual)
+}
+
 func TestWriteRow(t *testing.T) {
 	tmpExporter := getTemporaryJSONExporter()
 	str := "sample-string"


### PR DESCRIPTION
Figured out last-modified timestamp from file is getting ignored when we restart the export.