### PR TITLE
[INTG-1656] Insert actions in batches to the DB

### DIFF
--- a/internal/app/feed/feed_action.go
+++ b/internal/app/feed/feed_action.go
@@ -116,7 +116,7 @@ func (f *ActionFeed) Export(ctx context.Context, apiClient api.Client, exporter 
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer to account for primary keys
 			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 
 			for i := 0; i < len(rows); i += batchSize {

--- a/internal/app/feed/feed_action.go
+++ b/internal/app/feed/feed_action.go
@@ -67,6 +67,7 @@ func (f *ActionFeed) Columns() []string {
 		"due_date",
 		"created_at",
 		"modified_at",
+		"exported_at",
 		"creator_user_id",
 		"creator_user_name",
 		"template_id",
@@ -115,8 +116,18 @@ func (f *ActionFeed) Export(ctx context.Context, apiClient api.Client, exporter 
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			err = exporter.WriteRows(f, rows)
-			util.Check(err, "Failed to write data to exporter")
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
+
+			for i := 0; i < len(rows); i += batchSize {
+				j := i + batchSize
+				if j > len(rows) {
+					j = len(rows)
+				}
+
+				err = exporter.WriteRows(f, rows[i:j])
+				util.Check(err, "Failed to write data to exporter")
+			}
 		}
 
 		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)

--- a/internal/app/feed/feed_action_assignees.go
+++ b/internal/app/feed/feed_action_assignees.go
@@ -94,7 +94,7 @@ func (f *ActionAssigneeFeed) Export(ctx context.Context, apiClient api.Client, e
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer to account for primary keys
 			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 
 			for i := 0; i < len(rows); i += batchSize {

--- a/internal/app/feed/feed_action_assignees.go
+++ b/internal/app/feed/feed_action_assignees.go
@@ -94,8 +94,18 @@ func (f *ActionAssigneeFeed) Export(ctx context.Context, apiClient api.Client, e
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			err = exporter.WriteRows(f, rows)
-			util.Check(err, "Failed to write data to exporter")
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
+
+			for i := 0; i < len(rows); i += batchSize {
+				j := i + batchSize
+				if j > len(rows) {
+					j = len(rows)
+				}
+
+				err = exporter.WriteRows(f, rows[i:j])
+				util.Check(err, "Failed to write data to exporter")
+			}
 		}
 
 		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)

--- a/internal/app/feed/feed_group.go
+++ b/internal/app/feed/feed_group.go
@@ -80,7 +80,7 @@ func (f *GroupFeed) Export(ctx context.Context, apiClient api.Client, exporter E
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer to account for primary keys
 			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 
 			for i := 0; i < len(rows); i += batchSize {

--- a/internal/app/feed/feed_group_user.go
+++ b/internal/app/feed/feed_group_user.go
@@ -81,7 +81,7 @@ func (f *GroupUserFeed) Export(ctx context.Context, apiClient api.Client, export
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer to account for primary keys
 			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 
 			for i := 0; i < len(rows); i += batchSize {

--- a/internal/app/feed/feed_inspection.go
+++ b/internal/app/feed/feed_inspection.go
@@ -118,7 +118,7 @@ func (f *InspectionFeed) writeRows(exporter Exporter, rows []*Inspection) error 
 		skipIDs[id] = true
 	}
 
-	// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+	// Calculate the size of the batch we can insert into the DB at once. Column count + buffer to account for primary keys
 	batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 	for i := 0; i < len(rows); i += batchSize {
 		j := i + batchSize

--- a/internal/app/feed/feed_inspection_item.go
+++ b/internal/app/feed/feed_inspection_item.go
@@ -137,7 +137,7 @@ func (f *InspectionItemFeed) writeRows(ctx context.Context, exporter Exporter, r
 		skipIDs[id] = true
 	}
 
-	// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+	// Calculate the size of the batch we can insert into the DB at once. Column count + buffer to account for primary keys
 	batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 	for i := 0; i < len(rows); i += batchSize {
 		j := i + batchSize

--- a/internal/app/feed/feed_schedule.go
+++ b/internal/app/feed/feed_schedule.go
@@ -112,7 +112,7 @@ func (f *ScheduleFeed) Export(ctx context.Context, apiClient api.Client, exporte
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer to account for primary keys
 			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 
 			for i := 0; i < len(rows); i += batchSize {

--- a/internal/app/feed/feed_schedule_assginee.go
+++ b/internal/app/feed/feed_schedule_assginee.go
@@ -88,7 +88,7 @@ func (f *ScheduleAssigneeFeed) Export(ctx context.Context, apiClient api.Client,
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer to account for primary keys
 			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 
 			for i := 0; i < len(rows); i += batchSize {

--- a/internal/app/feed/feed_schedule_occurrence.go
+++ b/internal/app/feed/feed_schedule_occurrence.go
@@ -114,7 +114,7 @@ func (f *ScheduleOccurrenceFeed) Export(ctx context.Context, apiClient api.Clien
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer to account for primary keys
 			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 
 			for i := 0; i < len(rows); i += batchSize {

--- a/internal/app/feed/feed_site.go
+++ b/internal/app/feed/feed_site.go
@@ -89,7 +89,7 @@ func (f *SiteFeed) Export(ctx context.Context, apiClient api.Client, exporter Ex
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer to account for primary keys
 			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 
 			for i := 0; i < len(rows); i += batchSize {

--- a/internal/app/feed/feed_template.go
+++ b/internal/app/feed/feed_template.go
@@ -104,7 +104,7 @@ func (f *TemplateFeed) Export(ctx context.Context, apiClient api.Client, exporte
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer to account for primary keys
 			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 
 			for i := 0; i < len(rows); i += batchSize {

--- a/internal/app/feed/feed_template_permission.go
+++ b/internal/app/feed/feed_template_permission.go
@@ -88,7 +88,7 @@ func (f *TemplatePermissionFeed) Export(ctx context.Context, apiClient api.Clien
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer to account for primary keys
 			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 
 			for i := 0; i < len(rows); i += batchSize {

--- a/internal/app/feed/feed_user.go
+++ b/internal/app/feed/feed_user.go
@@ -88,7 +88,7 @@ func (f *UserFeed) Export(ctx context.Context, apiClient api.Client, exporter Ex
 		util.Check(err, "Failed to unmarshal data to struct")
 
 		if len(rows) != 0 {
-			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer
+			// Calculate the size of the batch we can insert into the DB at once. Column count + buffer to account for primary keys
 			batchSize := exporter.ParameterLimit() / (len(f.Columns()) + 4)
 
 			for i := 0; i < len(rows); i += batchSize {


### PR DESCRIPTION
Inserts actions in batches to the DB. This impacts SQL Server predominantly as it can only support 2100 parameters in a single query.

