### PR TITLE
[CPR-2302] Add additional logging to request flows

### DIFF
--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -240,6 +240,7 @@ func (a *apiClient) do(sl *sling.Sling, req *http.Request, successV, failureV in
 		logger.Errorw("http request error status",
 			"url", req.URL.String(),
 			"status", status,
+			"err", failureV,
 		)
 		return res, errors.Errorf("request error status: %s", status)
 	}

--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -213,8 +213,6 @@ type ListInspectionsResponse struct {
 }
 
 func (a *apiClient) do(sl *sling.Sling, req *http.Request, successV, failureV interface{}) (*http.Response, error) {
-	var errMsg json.RawMessage
-
 	logger := util.GetLogger()
 
 	logger.Debugw("http request",
@@ -237,14 +235,6 @@ func (a *apiClient) do(sl *sling.Sling, req *http.Request, successV, failureV in
 			"err", err,
 		)
 		return res, errors.Wrap(err, "request error")
-	}
-	if errMsg != nil {
-		logger.Errorw("http request error msg",
-			"url", req.URL.String(),
-			"status", status,
-			"err", errMsg,
-		)
-		return res, errors.Errorf("request error: %s", errMsg)
 	}
 	if res != nil && (res.StatusCode > 299 || res.StatusCode < 200) {
 		logger.Errorw("http request error status",

--- a/internal/app/api/api_test.go
+++ b/internal/app/api/api_test.go
@@ -396,7 +396,7 @@ func TestAPIClientInitiateInspectionReportExport_should_return_error_on_failure(
 	_, err := apiClient.InitiateInspectionReportExport(context.Background(), "audit_123", "PDF", "")
 
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "something bad happened")
+	assert.Contains(t, err.Error(), "500 Internal Server Error")
 }
 
 func TestAPIClientCheckInspectionReportExportCompletion_should_return_status(t *testing.T) {
@@ -434,7 +434,7 @@ func TestAPIClientCheckInspectionReportExportCompletion_should_return_error_on_f
 	_, err := apiClient.CheckInspectionReportExportCompletion(context.Background(), "audit_123", "abc")
 
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "something bad happened")
+	assert.Contains(t, err.Error(), "500 Internal Server Error")
 }
 
 func TestAPIClientDownloadInspectionReportFile_should_return_status(t *testing.T) {

--- a/internal/app/feed/utils_test.go
+++ b/internal/app/feed/utils_test.go
@@ -115,7 +115,10 @@ func fileExists(t *testing.T, expectedPath string) {
 
 func getFileModTime(filePath string) (time.Time, error) {
 	file, err := os.Stat(filePath)
-	return file.ModTime(), err
+	if err != nil {
+		return time.Time{}, err
+	}
+	return file.ModTime(), nil
 }
 
 func countFileLines(filePath string) (int, error) {


### PR DESCRIPTION
Adds additional logging to the request flows to ensure we can debug failed requests.