### PR TITLE
INTG-1686: remove tabs from the name

### DIFF
--- a/internal/app/feed/exporter_report.go
+++ b/internal/app/feed/exporter_report.go
@@ -296,7 +296,7 @@ func saveReportResponse(resp io.ReadCloser, inspection *Inspection, path string,
 func sanitizeName(name string) string {
 	res := strings.ReplaceAll(name, " / ", "-")
 	res = strings.ReplaceAll(res, " // ", "-")
-	var rx = regexp.MustCompile(`[/\\?%*:|"<> ]`)
+	var rx = regexp.MustCompile(`[/\\?%*:|"<> \t\n]`)
 	res = rx.ReplaceAllString(res, "-")
 	return res
 }


### PR DESCRIPTION
We got an issue raised by one of customers related to report export failing in some cases.
After some investigation I found out for some reason they have `tabs` in the name of inspections and that causes the exporter to fail.