### PR TITLE
[INTG-1667] Rate limiting and retry handling for all the API requests

### DIFF
--- a/cmd/iauditor-exporter/cmd/export/export.go
+++ b/cmd/iauditor-exporter/cmd/export/export.go
@@ -80,7 +80,7 @@ func ReportCmd() *cobra.Command {
 	}
 }
 
-func getAPIClient() api.Client {
+func getAPIClient() *api.Client {
 	apiOpts := []api.Opt{}
 	if viper.GetBool("api.tls_skip_verify") {
 		apiOpts = append(apiOpts, api.OptSetInsecureTLS(true))
@@ -94,7 +94,7 @@ func getAPIClient() api.Client {
 		apiOpts = append(apiOpts, api.OptSetProxy(proxyURL))
 	}
 
-	return api.NewAPIClient(
+	return api.NewClient(
 		viper.GetString("api.url"),
 		viper.GetString("access_token"),
 		apiOpts...,

--- a/internal/app/api/api_test.go
+++ b/internal/app/api/api_test.go
@@ -56,7 +56,7 @@ func TestAPIClientDrainFeed_should_return_for_as_long_next_page_set(t *testing.T
 			]
 		}`)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	calls := 0
@@ -101,7 +101,7 @@ func TestAPIClientDrainFeed_should_bubble_up_errors_from_callback(t *testing.T) 
 			"data": []
 		}`)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	expectedErr := errors.New("test error")
@@ -135,7 +135,7 @@ func TestAPIClientDrainFeed_should_return_api_errors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+			apiClient := api.NewClient("http://localhost:9999", "abc123")
 			gock.InterceptClient(apiClient.HTTPClient())
 
 			apiClient.RetryWaitMin = 10 * time.Millisecond
@@ -156,7 +156,7 @@ func TestAPIClientDrainFeed_should_return_api_errors(t *testing.T) {
 }
 
 func TestApiOptSetTimeout_should_set_timeout(t *testing.T) {
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123", api.OptSetTimeout(time.Second*21))
+	apiClient := api.NewClient("http://localhost:9999", "abc123", api.OptSetTimeout(time.Second*21))
 
 	assert.Equal(t, time.Second*21, apiClient.HTTPClient().Timeout)
 }
@@ -180,7 +180,7 @@ func TestAPIClientDrainInspections_should_return_for_as_long_next_page_set(t *te
 			]
 		}`)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	auditIDs := []string{}
@@ -212,7 +212,7 @@ func TestAPIClientGetInspection(t *testing.T) {
 			"audit_id": "audit_8E2B1F3CB9C94D8792957F9F99E2E4BD"
 		}`)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	resp, err := apiClient.GetInspection(context.Background(), auditID)
@@ -235,7 +235,7 @@ func TestAPIClientGetInspectionWithError(t *testing.T) {
 		Get(fmt.Sprintf("/audits/%s", auditID)).
 		ReplyError(fmt.Errorf("test error"))
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	_, err := apiClient.GetInspection(context.Background(), auditID)
@@ -249,7 +249,7 @@ func TestAPIClientListInspectionWithError(t *testing.T) {
 		Get("/audits/search").
 		ReplyError(fmt.Errorf("test error"))
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	_, err := apiClient.ListInspections(context.Background(), nil)
@@ -263,7 +263,7 @@ func TestDrainInspectionsWithAPIError(t *testing.T) {
 		Get("/audits/search").
 		ReplyError(fmt.Errorf("test error"))
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	err := apiClient.DrainInspections(
@@ -294,7 +294,7 @@ func TestDrainInspectionsWithCallbackError(t *testing.T) {
 			]
 		}`)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	err := apiClient.DrainInspections(
@@ -313,7 +313,7 @@ func TestGetMediaWithAPIError(t *testing.T) {
 		Get("/audits/1234/media/12345").
 		ReplyError(fmt.Errorf("test error"))
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	_, err := apiClient.GetMedia(
@@ -335,7 +335,7 @@ func TestGetMediaWith204Error(t *testing.T) {
 		Reply(204).
 		BodyString(result)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	resp, err := apiClient.GetMedia(
@@ -358,7 +358,7 @@ func TestGetMediaWithNoContentType(t *testing.T) {
 		Reply(200).
 		BodyString(result)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	_, err := apiClient.GetMedia(
@@ -383,7 +383,7 @@ func TestGetMedia(t *testing.T) {
 		BodyString(result)
 	req.SetHeader("Content-Type", "test-content")
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	expected := &api.GetMediaResponse{
@@ -416,7 +416,7 @@ func TestAPIClientInitiateInspectionReportExport_should_return_messageID(t *test
 			"messageId": "abc"
 		}`)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	mId, err := apiClient.InitiateInspectionReportExport(context.Background(), "audit_123", "PDF", "p123")
@@ -448,7 +448,7 @@ func TestAPIClientInitiateInspectionReportExport_should_return_error_on_failure(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+			apiClient := api.NewClient("http://localhost:9999", "abc123")
 			gock.InterceptClient(apiClient.HTTPClient())
 
 			apiClient.RetryWaitMin = 10 * time.Millisecond
@@ -475,7 +475,7 @@ func TestAPIClientCheckInspectionReportExportCompletion_should_return_status(t *
 			"url": "http://domain.com/report"
 		}`)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	res, err := apiClient.CheckInspectionReportExportCompletion(context.Background(), "audit_123", "abc")
@@ -507,7 +507,7 @@ func TestAPIClientCheckInspectionReportExportCompletion_should_return_error_on_f
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+			apiClient := api.NewClient("http://localhost:9999", "abc123")
 			gock.InterceptClient(apiClient.HTTPClient())
 
 			apiClient.RetryWaitMin = 10 * time.Millisecond
@@ -531,7 +531,7 @@ func TestAPIClientDownloadInspectionReportFile_should_return_status(t *testing.T
 		Reply(200).
 		Body(bytes.NewBuffer([]byte(`file content`)))
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 
 	res, err := apiClient.DownloadInspectionReportFile(context.Background(), "http://localhost:9999/report-exports/abc")
@@ -565,7 +565,7 @@ func TestAPIClientDownloadInspectionReportFile_should_return_error_on_failure(t 
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+			apiClient := api.NewClient("http://localhost:9999", "abc123")
 			gock.InterceptClient(apiClient.HTTPClient())
 
 			apiClient.RetryWaitMin = 10 * time.Millisecond
@@ -604,7 +604,7 @@ func TestAPIClientBackoff429TooManyRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+			apiClient := api.NewClient("http://localhost:9999", "abc123")
 			gock.InterceptClient(apiClient.HTTPClient())
 			apiClient.RetryMax = 1
 

--- a/internal/app/api/http_utils.go
+++ b/internal/app/api/http_utils.go
@@ -1,5 +1,11 @@
 package api
 
+import (
+	"net/http"
+
+	"github.com/dghubble/sling"
+)
+
 // Header is used to represent name of a header
 type Header string
 
@@ -10,4 +16,48 @@ const (
 	XRequestID         Header = "X-Request-ID"
 	IntegrationID      Header = "sc-integration-id"
 	IntegrationVersion Header = "sc-integration-version"
+	XRateLimitReset    Header = "X-Rate-Limit-Reset"
 )
+
+// HTTPDoer executes http requests.
+type HTTPDoer interface {
+	Do() (*http.Response, error)
+	URL() string
+	Error() interface{}
+}
+
+type slingHTTPDoer struct {
+	sl       *sling.Sling
+	req      *http.Request
+	successV interface{}
+	failureV interface{}
+}
+
+func (b *slingHTTPDoer) Do() (*http.Response, error) {
+	return b.sl.Do(b.req, b.successV, b.failureV)
+}
+
+func (b *slingHTTPDoer) URL() string {
+	return b.req.URL.String()
+}
+
+func (b *slingHTTPDoer) Error() interface{} {
+	return b.failureV
+}
+
+type defaultHTTPDoer struct {
+	req        *http.Request
+	httpClient *http.Client
+}
+
+func (b *defaultHTTPDoer) Do() (*http.Response, error) {
+	return b.httpClient.Do(b.req)
+}
+
+func (b *defaultHTTPDoer) URL() string {
+	return b.req.URL.String()
+}
+
+func (b *defaultHTTPDoer) Error() interface{} {
+	return nil
+}

--- a/internal/app/api/retry.go
+++ b/internal/app/api/retry.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// CheckForRetry specifies a policy for handling retries. It is called
+// following each request with the response and error values returned by
+// the http.Client. If it returns false, the Client stops retrying
+// and returns the response to the caller. If it returns an error,
+// that error value is returned in lieu of the error from the request.
+type CheckForRetry func(resp *http.Response, err error) (bool, error)
+
+// DefaultRetryPolicy provides a default callback for CheckForRetry.
+func DefaultRetryPolicy(resp *http.Response, err error) (bool, error) {
+	// Retry for a genuine error
+	if err != nil {
+		return true, err
+	}
+	switch status := resp.StatusCode; {
+	case status >= http.StatusInternalServerError:
+		return true, nil
+	case status == http.StatusTooManyRequests:
+		return true, nil
+	}
+	return false, nil
+}
+
+// Backoff specifies a policy for how long to wait between retries.
+// It is called after a failing request to determine the amount of time
+// that should pass before trying again.
+type Backoff func(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration
+
+// DefaultBackoff provides a default callback for Backoff which will perform
+// exponential backoff based on the attempt number and limited by the provided
+// minimum and maximum durations.
+// It also tries to parse XRateLimitReset response header when a http.StatusTooManyRequests
+// (HTTP Code 429) is found in the resp parameter. Hence it will return the number of
+// seconds the server states it may be ready to process more requests from this client.
+func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+		if s, ok := resp.Header[string(XRateLimitReset)]; ok {
+			if sleep, err := strconv.ParseInt(s[0], 10, 64); err == nil {
+				// Convert the times to UTC and allow 1 second of allowance.
+				now := time.Now().UTC()
+				return time.Unix(sleep/1000, 0).UTC().Sub(now) + 1*time.Second
+			}
+		}
+	}
+
+	mult := math.Pow(2, float64(attemptNum)) * float64(min)
+	sleep := time.Duration(mult)
+	if float64(sleep) != mult || sleep > max {
+		sleep = max
+	}
+	return sleep
+}

--- a/internal/app/feed/export_feeds.go
+++ b/internal/app/feed/export_feeds.go
@@ -116,7 +116,7 @@ func WriteSchemas(v *viper.Viper, exporter *SchemaExporter) error {
 }
 
 // ExportFeeds fetches all the feeds data from server and stores them in the format provided
-func ExportFeeds(v *viper.Viper, apiClient api.Client, exporter Exporter) error {
+func ExportFeeds(v *viper.Viper, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	ctx := context.Background()
 
@@ -150,7 +150,7 @@ func ExportFeeds(v *viper.Viper, apiClient api.Client, exporter Exporter) error 
 }
 
 // ExportInspectionReports download all the reports for inspections and stores them on disk
-func ExportInspectionReports(v *viper.Viper, apiClient api.Client, exporter *ReportExporter) error {
+func ExportInspectionReports(v *viper.Viper, apiClient *api.Client, exporter *ReportExporter) error {
 	logger := util.GetLogger()
 	ctx := context.Background()
 

--- a/internal/app/feed/export_feeds_intg_test.go
+++ b/internal/app/feed/export_feeds_intg_test.go
@@ -53,7 +53,7 @@ func TestIntegrationDbExportFeeds_should_export_all_feeds_to_file(t *testing.T) 
 
 	viperConfig := viper.New()
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	initMockFeedsSet1(apiClient.HTTPClient())
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
@@ -87,7 +87,7 @@ func TestIntegrationDbExportFeeds_should_perform_incremental_update_on_second_ru
 	viperConfig := viper.New()
 	viperConfig.Set("export.incremental", true)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	initMockFeedsSet1(apiClient.HTTPClient())
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
@@ -123,7 +123,7 @@ func TestIntegrationDbExportFeeds_should_handle_lots_of_rows_ok(t *testing.T) {
 	viperConfig := viper.New()
 	viperConfig.Set("export.incremental", true)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	initMockFeedsSet3(apiClient.HTTPClient())
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)

--- a/internal/app/feed/export_feeds_soak_test.go
+++ b/internal/app/feed/export_feeds_soak_test.go
@@ -23,7 +23,7 @@ func TestIntegrationDbSoakExportFeeds_should_successfully_export_with_significan
 
 	viperConfig := viper.New()
 
-	apiClient := api.NewAPIClient(os.Getenv("TEST_API_HOST"), os.Getenv("TEST_ACCESS_TOKEN"))
+	apiClient := api.NewClient(os.Getenv("TEST_API_HOST"), os.Getenv("TEST_ACCESS_TOKEN"))
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
 	assert.Nil(t, err)

--- a/internal/app/feed/export_feeds_test.go
+++ b/internal/app/feed/export_feeds_test.go
@@ -44,7 +44,7 @@ func TestExportFeeds_should_export_all_feeds_to_file(t *testing.T) {
 	viperConfig := viper.New()
 	viperConfig.Set("export.site.include_deleted", true)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	initMockFeedsSet1(apiClient.HTTPClient())
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
@@ -79,7 +79,7 @@ func TestExportFeeds_should_perform_incremental_update_on_second_run(t *testing.
 	viperConfig.Set("export.incremental", true)
 	viperConfig.Set("export.site.include_deleted", true)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	initMockFeedsSet1(apiClient.HTTPClient())
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)
@@ -116,7 +116,7 @@ func TestExportFeeds_should_handle_lots_of_rows_ok(t *testing.T) {
 	viperConfig := viper.New()
 	viperConfig.Set("export.incremental", true)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	initMockFeedsSet3(apiClient.HTTPClient())
 
 	err = feed.ExportFeeds(viperConfig, apiClient, exporter)

--- a/internal/app/feed/exporter_report.go
+++ b/internal/app/feed/exporter_report.go
@@ -49,7 +49,7 @@ type reportExportResult struct {
 }
 
 // SaveReports downloads and stores inspection reports on disk
-func (e *ReportExporter) SaveReports(ctx context.Context, apiClient api.Client, feed *InspectionFeed) error {
+func (e *ReportExporter) SaveReports(ctx context.Context, apiClient *api.Client, feed *InspectionFeed) error {
 	e.Logger.Info("Generating inspection reports")
 
 	format, err := e.getFormats()
@@ -155,7 +155,7 @@ func (e *ReportExporter) getFormats() (*reportExportFormat, error) {
 	return format, nil
 }
 
-func (e *ReportExporter) saveReport(ctx context.Context, apiClient api.Client, inspection *Inspection, format *reportExportFormat) *reportExport {
+func (e *ReportExporter) saveReport(ctx context.Context, apiClient *api.Client, inspection *Inspection, format *reportExportFormat) *reportExport {
 	exportPDF, exportWORD := format.PDF, format.WORD
 
 	report := &reportExport{}
@@ -208,7 +208,7 @@ func (e *ReportExporter) saveReport(ctx context.Context, apiClient api.Client, i
 	return report
 }
 
-func (e *ReportExporter) exportInspection(ctx context.Context, apiClient api.Client, inspection *Inspection, format string) error {
+func (e *ReportExporter) exportInspection(ctx context.Context, apiClient *api.Client, inspection *Inspection, format string) error {
 	messageID, err := apiClient.InitiateInspectionReportExport(ctx, inspection.ID, format, e.PreferenceID)
 	if err != nil {
 		return err

--- a/internal/app/feed/exporter_report_test.go
+++ b/internal/app/feed/exporter_report_test.go
@@ -32,7 +32,7 @@ func TestExportReports_should_export_all_reports(t *testing.T) {
 
 	viperConfig := viper.New()
 
-	apiClient := api.NewAPIClient(mockAPIBaseURL, "token")
+	apiClient := api.NewClient(mockAPIBaseURL, "token")
 	defer resetMocks(apiClient.HTTPClient())
 	initMockFeedsSet1(apiClient.HTTPClient())
 
@@ -73,7 +73,7 @@ func TestExportReports_should_not_run_if_all_exported(t *testing.T) {
 	viperConfig := viper.New()
 	viperConfig.Set("export.incremental", true)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	defer resetMocks(apiClient.HTTPClient())
 	initMockFeedsSet1(apiClient.HTTPClient())
 
@@ -124,7 +124,7 @@ func TestExportReports_should_take_care_of_invalid_file_names(t *testing.T) {
 	viperConfig := viper.New()
 	viperConfig.Set("export.incremental", true)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	defer resetMocks(apiClient.HTTPClient())
 	gock.InterceptClient(apiClient.HTTPClient())
 
@@ -172,7 +172,7 @@ func TestExportReports_should_fail_after_retries(t *testing.T) {
 
 	viperConfig := viper.New()
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	defer resetMocks(apiClient.HTTPClient())
 	initMockFeedsSet1(apiClient.HTTPClient())
 
@@ -200,7 +200,7 @@ func TestExportReports_should_fail_if_report_status_fails(t *testing.T) {
 
 	viperConfig := viper.New()
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	defer resetMocks(apiClient.HTTPClient())
 	initMockFeedsSet1(apiClient.HTTPClient())
 
@@ -227,7 +227,7 @@ func TestExportReports_should_fail_if_init_report_reply_is_not_success(t *testin
 
 	viperConfig := viper.New()
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	defer resetMocks(apiClient.HTTPClient())
 	initMockFeedsSet1(apiClient.HTTPClient())
 
@@ -248,7 +248,7 @@ func TestExportReports_should_fail_if_report_completion_reply_is_not_success(t *
 
 	viperConfig := viper.New()
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	defer resetMocks(apiClient.HTTPClient())
 	initMockFeedsSet1(apiClient.HTTPClient())
 
@@ -275,7 +275,7 @@ func TestExportReports_should_fail_if_download_report_reply_is_not_success(t *te
 
 	viperConfig := viper.New()
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	defer resetMocks(apiClient.HTTPClient())
 	initMockFeedsSet1(apiClient.HTTPClient())
 
@@ -308,7 +308,7 @@ func TestExportReports_should_return_error_for_unsupported_format(t *testing.T) 
 
 	viperConfig := viper.New()
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	initMockFeedsSet1(apiClient.HTTPClient())
 
 	err = feed.ExportInspectionReports(viperConfig, apiClient, exporter)

--- a/internal/app/feed/feed.go
+++ b/internal/app/feed/feed.go
@@ -18,7 +18,7 @@ type Feed interface {
 	Order() string
 
 	CreateSchema(exporter Exporter) error
-	Export(ctx context.Context, apiClient api.Client, exporter Exporter) error
+	Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error
 }
 
 // InitFeedOptions contains the options used when initialising a feed

--- a/internal/app/feed/feed_action.go
+++ b/internal/app/feed/feed_action.go
@@ -89,7 +89,7 @@ func (f *ActionFeed) CreateSchema(exporter Exporter) error {
 }
 
 // Export exports the feed to the supplied exporter
-func (f *ActionFeed) Export(ctx context.Context, apiClient api.Client, exporter Exporter) error {
+func (f *ActionFeed) Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	feedName := f.Name()
 

--- a/internal/app/feed/feed_action_assignees.go
+++ b/internal/app/feed/feed_action_assignees.go
@@ -67,7 +67,7 @@ func (f *ActionAssigneeFeed) CreateSchema(exporter Exporter) error {
 }
 
 // Export exports the feed to the supplied exporter
-func (f *ActionAssigneeFeed) Export(ctx context.Context, apiClient api.Client, exporter Exporter) error {
+func (f *ActionAssigneeFeed) Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	feedName := f.Name()
 

--- a/internal/app/feed/feed_group.go
+++ b/internal/app/feed/feed_group.go
@@ -58,7 +58,7 @@ func (f *GroupFeed) CreateSchema(exporter Exporter) error {
 }
 
 // Export exports the feed to the supplied exporter
-func (f *GroupFeed) Export(ctx context.Context, apiClient api.Client, exporter Exporter) error {
+func (f *GroupFeed) Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	feedName := f.Name()
 

--- a/internal/app/feed/feed_group_user.go
+++ b/internal/app/feed/feed_group_user.go
@@ -59,7 +59,7 @@ func (f *GroupUserFeed) CreateSchema(exporter Exporter) error {
 }
 
 // Export exports the feed to the supplied exporter
-func (f *GroupUserFeed) Export(ctx context.Context, apiClient api.Client, exporter Exporter) error {
+func (f *GroupUserFeed) Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	feedName := f.Name()
 

--- a/internal/app/feed/feed_inspection.go
+++ b/internal/app/feed/feed_inspection.go
@@ -151,7 +151,7 @@ func (f *InspectionFeed) CreateSchema(exporter Exporter) error {
 }
 
 // Export exports the feed to the supplied exporter
-func (f *InspectionFeed) Export(ctx context.Context, apiClient api.Client, exporter Exporter) error {
+func (f *InspectionFeed) Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	feedName := f.Name()
 

--- a/internal/app/feed/feed_inspection_item.go
+++ b/internal/app/feed/feed_inspection_item.go
@@ -113,7 +113,7 @@ func (f *InspectionItemFeed) Order() string {
 	return "modified_at ASC, id"
 }
 
-func fetchAndWriteMedia(ctx context.Context, apiClient api.Client, exporter Exporter, auditID, mediaURL string) error {
+func fetchAndWriteMedia(ctx context.Context, apiClient *api.Client, exporter Exporter, auditID, mediaURL string) error {
 	resp, err := apiClient.GetMedia(
 		ctx,
 		&api.GetMediaRequest{
@@ -133,7 +133,7 @@ func fetchAndWriteMedia(ctx context.Context, apiClient api.Client, exporter Expo
 	return nil
 }
 
-func (f *InspectionItemFeed) writeRows(ctx context.Context, exporter Exporter, rows []*InspectionItem, apiClient api.Client) error {
+func (f *InspectionItemFeed) writeRows(ctx context.Context, exporter Exporter, rows []*InspectionItem, apiClient *api.Client) error {
 	skipIDs := map[string]bool{}
 	for _, id := range f.SkipIDs {
 		skipIDs[id] = true
@@ -200,7 +200,7 @@ func (f *InspectionItemFeed) CreateSchema(exporter Exporter) error {
 }
 
 // Export exports the feed to the supplied exporter
-func (f *InspectionItemFeed) Export(ctx context.Context, apiClient api.Client, exporter Exporter) error {
+func (f *InspectionItemFeed) Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	feedName := f.Name()
 

--- a/internal/app/feed/feed_inspection_item_test.go
+++ b/internal/app/feed/feed_inspection_item_test.go
@@ -17,7 +17,7 @@ func TestInspectionItemFeedExport_should_export_rows_to_sql_db(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
 	assert.Nil(t, err)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	initMockFeedsSet1(apiClient.HTTPClient())
 
 	inspectionItemFeed := feed.InspectionItemFeed{
@@ -53,7 +53,7 @@ func TestInspectionItemFeedExportWithMedia(t *testing.T) {
 		BodyString(result)
 	req.SetHeader("Content-Type", "image/test-content")
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	gock.InterceptClient(apiClient.HTTPClient())
 	initMockFeedsSet1(apiClient.HTTPClient())
 

--- a/internal/app/feed/feed_inspection_test.go
+++ b/internal/app/feed/feed_inspection_test.go
@@ -15,7 +15,7 @@ func TestInspectionFeedExport_should_export_rows_to_sql_db(t *testing.T) {
 	exporter, err := getInmemorySQLExporter("")
 	assert.Nil(t, err)
 
-	apiClient := api.NewAPIClient("http://localhost:9999", "abc123")
+	apiClient := api.NewClient("http://localhost:9999", "abc123")
 	initMockFeedsSet1(apiClient.HTTPClient())
 
 	inspectionsFeed := feed.InspectionFeed{

--- a/internal/app/feed/feed_schedule.go
+++ b/internal/app/feed/feed_schedule.go
@@ -88,7 +88,7 @@ func (f *ScheduleFeed) CreateSchema(exporter Exporter) error {
 }
 
 // Export exports the feed to the supplied exporter
-func (f *ScheduleFeed) Export(ctx context.Context, apiClient api.Client, exporter Exporter) error {
+func (f *ScheduleFeed) Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	feedName := f.Name()
 

--- a/internal/app/feed/feed_schedule_assginee.go
+++ b/internal/app/feed/feed_schedule_assginee.go
@@ -65,7 +65,7 @@ func (f *ScheduleAssigneeFeed) CreateSchema(exporter Exporter) error {
 }
 
 // Export exports the feed to the supplied exporter
-func (f *ScheduleAssigneeFeed) Export(ctx context.Context, apiClient api.Client, exporter Exporter) error {
+func (f *ScheduleAssigneeFeed) Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	feedName := f.Name()
 

--- a/internal/app/feed/feed_schedule_occurrence.go
+++ b/internal/app/feed/feed_schedule_occurrence.go
@@ -91,7 +91,7 @@ func (f *ScheduleOccurrenceFeed) writeRows(exporter Exporter, rows []*ScheduleOc
 }
 
 // Export exports the feed to the supplied exporter
-func (f *ScheduleOccurrenceFeed) Export(ctx context.Context, apiClient api.Client, exporter Exporter) error {
+func (f *ScheduleOccurrenceFeed) Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	feedName := f.Name()
 

--- a/internal/app/feed/feed_site.go
+++ b/internal/app/feed/feed_site.go
@@ -65,7 +65,7 @@ func (f *SiteFeed) CreateSchema(exporter Exporter) error {
 }
 
 // Export exports the feed to the supplied exporter
-func (f *SiteFeed) Export(ctx context.Context, apiClient api.Client, exporter Exporter) error {
+func (f *SiteFeed) Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	feedName := f.Name()
 

--- a/internal/app/feed/feed_template.go
+++ b/internal/app/feed/feed_template.go
@@ -77,7 +77,7 @@ func (f *TemplateFeed) CreateSchema(exporter Exporter) error {
 }
 
 // Export exports the feed to the supplied exporter
-func (f *TemplateFeed) Export(ctx context.Context, apiClient api.Client, exporter Exporter) error {
+func (f *TemplateFeed) Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	feedName := f.Name()
 

--- a/internal/app/feed/feed_template_permission.go
+++ b/internal/app/feed/feed_template_permission.go
@@ -65,7 +65,7 @@ func (f *TemplatePermissionFeed) CreateSchema(exporter Exporter) error {
 }
 
 // Export exports the feed to the supplied exporter
-func (f *TemplatePermissionFeed) Export(ctx context.Context, apiClient api.Client, exporter Exporter) error {
+func (f *TemplatePermissionFeed) Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	feedName := f.Name()
 

--- a/internal/app/feed/feed_user.go
+++ b/internal/app/feed/feed_user.go
@@ -66,7 +66,7 @@ func (f *UserFeed) CreateSchema(exporter Exporter) error {
 }
 
 // Export exports the feed to the supplied exporter
-func (f *UserFeed) Export(ctx context.Context, apiClient api.Client, exporter Exporter) error {
+func (f *UserFeed) Export(ctx context.Context, apiClient *api.Client, exporter Exporter) error {
 	logger := util.GetLogger()
 	feedName := f.Name()
 

--- a/internal/app/inspections/inspections.go
+++ b/internal/app/inspections/inspections.go
@@ -19,7 +19,7 @@ const maxGoRoutines = 10
 type inspectionClient struct {
 	*zap.SugaredLogger
 
-	apiClient     api.Client
+	apiClient     *api.Client
 	exporter      exporter.Exporter
 	SkipIDs       []string
 	ModifiedAfter time.Time
@@ -35,7 +35,7 @@ type InspectionClient interface {
 }
 
 // NewInspectionClient returns a new instance of InspectionClient
-func NewInspectionClient(v *viper.Viper, apiClient api.Client, exporter exporter.Exporter) InspectionClient {
+func NewInspectionClient(v *viper.Viper, apiClient *api.Client, exporter exporter.Exporter) InspectionClient {
 	inspectionConfig := config.GetInspectionConfig(v)
 	templateIDs := v.GetStringSlice("export.template_ids")
 

--- a/internal/app/inspections/inspections_test.go
+++ b/internal/app/inspections/inspections_test.go
@@ -41,7 +41,7 @@ func initMockInspections(httpClient *http.Client) {
 func TestInspectionsExport(t *testing.T) {
 
 	viperConfig := viper.New()
-	apiClient := api.NewAPIClient("http://localhost:9999", "token")
+	apiClient := api.NewClient("http://localhost:9999", "token")
 	initMockInspections(apiClient.HTTPClient())
 
 	exporterMock := new(exportermock.Exporter)


### PR DESCRIPTION
1. The current API’s returns x-rate-limit-reset in the response headers which refers to the Unix timestamp the next request will be allowed. Client will sleep until that time and retries again.
2. Added retries 5** errors.