### PR TITLE
[INTG-1667] Ignore 404 errors for all the API's

### DIFF
--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -248,14 +248,12 @@ func (a *Client) do(doer HTTPDoer) (*http.Response, error) {
 		)
 
 		// Check if we should continue with the retries
-		shouldRetry, checkErr := a.CheckForRetry(resp, err)
+		shouldRetry, _ := a.CheckForRetry(resp, err)
 		if !shouldRetry {
-			if checkErr != nil {
-				err = checkErr
-			}
-			if resp == nil {
+			if err != nil {
 				return resp, err
 			}
+
 			switch status := resp.StatusCode; {
 			case status >= 200 && status <= 299:
 				return resp, nil

--- a/internal/app/api/api_test.go
+++ b/internal/app/api/api_test.go
@@ -321,12 +321,54 @@ func TestGetMediaWithAPIError(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestGetMediaWith403Error(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://localhost:9999").
+		Get("/audits/1234/media/12345").
+		Reply(403).
+		JSON(`{"error": "something bad happened"}`)
+
+	apiClient := api.GetTestClient()
+	gock.InterceptClient(apiClient.HTTPClient())
+
+	_, err := apiClient.GetMedia(
+		context.Background(),
+		&api.GetMediaRequest{
+			URL:     "http://localhost:9999/audits/1234/media/12345",
+			AuditID: "1234",
+		},
+	)
+	assert.Nil(t, err)
+}
+
 func TestGetMediaWith404Error(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("http://localhost:9999").
 		Get("/audits/1234/media/12345").
 		Reply(404).
+		JSON(`{"error": "something bad happened"}`)
+
+	apiClient := api.GetTestClient()
+	gock.InterceptClient(apiClient.HTTPClient())
+
+	_, err := apiClient.GetMedia(
+		context.Background(),
+		&api.GetMediaRequest{
+			URL:     "http://localhost:9999/audits/1234/media/12345",
+			AuditID: "1234",
+		},
+	)
+	assert.Nil(t, err)
+}
+
+func TestGetMediaWith405Error(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://localhost:9999").
+		Get("/audits/1234/media/12345").
+		Reply(405).
 		JSON(`{"error": "something bad happened"}`)
 
 	apiClient := api.GetTestClient()

--- a/internal/app/api/retry.go
+++ b/internal/app/api/retry.go
@@ -25,6 +25,8 @@ func DefaultRetryPolicy(resp *http.Response, err error) (bool, error) {
 		return true, nil
 	case status == http.StatusTooManyRequests:
 		return true, nil
+	case status == http.StatusNotFound:
+		return false, nil
 	}
 	return false, nil
 }

--- a/internal/app/feed/feed_inspection_item.go
+++ b/internal/app/feed/feed_inspection_item.go
@@ -125,6 +125,11 @@ func fetchAndWriteMedia(ctx context.Context, apiClient *api.Client, exporter Exp
 		return err
 	}
 
+	// If the response is empty, then ignore this media object
+	if resp == nil {
+		return nil
+	}
+
 	err = exporter.WriteMedia(auditID, resp.MediaID, resp.ContentType, resp.Body)
 	if err != nil {
 		return err


### PR DESCRIPTION
1. Ignoring 404 errors for all the API's.
2. Also ignoring 403 errors for some media objects. This happens if we upload `svg` files.  These files can be uploaded by frontend, but will be blocked by api-media and thus resulting with forbidden errors.