### PR TITLE
Upgrade go to 1.16, add support for building ARM64 binaries for darwin

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Setup release environment
         run: |-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,20 @@ builds:
       - -mod=readonly
     ldflags:
       - -s -w -X github.com/SafetyCulture/iauditor-exporter/internal/app/version.version={{.Version}}
+  - id: darwin-arm64
+    main: ./cmd/iauditor-exporter/main.go
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    flags:
+      - -tags=netgo  # Force using the go network stack
+      - -mod=readonly
+    ldflags:
+      - -s -w -X github.com/SafetyCulture/iauditor-exporter/internal/app/version.version={{.Version}}
   - id: linux-amd64
     main: ./cmd/iauditor-exporter/main.go
     goos:
@@ -59,6 +73,7 @@ archives:
   - id: iauditor-exporter
     builds:
       - darwin-amd64
+      - darwin-arm64
       - linux-amd64
       - windows-amd64
     replacements:
@@ -67,6 +82,7 @@ archives:
       windows: Windows
       386: i386
       amd64: x86_64
+      arm64: ARM
     format_overrides:
       - goos: windows
         format: zip

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE_NAME        	:= "github.com/safetyculture/iauditor-exporter"
-GOLANG_VERSION        ?= 1.15.3
+GOLANG_VERSION        ?= 1.16.1
 GOLANG_CROSS_VERSION  := v$(GOLANG_VERSION)
 
 .PHONY: help


### PR DESCRIPTION
I have tested the release process locally and it works, will test the ARM binary this evening on my machine at home to make sure it actually works.