### PR TITLE
[INTG-1762] iauditor-exporter Allow specifying inspection ID or name when saving PDF/Word files

### DIFF
--- a/cmd/iauditor-exporter/cmd/export/export.go
+++ b/cmd/iauditor-exporter/cmd/export/export.go
@@ -181,9 +181,9 @@ func runInspectionReports(cmd *cobra.Command, args []string) error {
 
 	format := viper.GetStringSlice("report.format")
 	preferenceID := viper.GetString("report.preference_id")
-	filename := viper.GetString("report.filename")
+	filenameConvention := viper.GetString("report.filename_convention")
 
-	exporter, err := feed.NewReportExporter(exportPath, format, preferenceID, filename)
+	exporter, err := feed.NewReportExporter(exportPath, format, preferenceID, filenameConvention)
 	util.Check(err, "unable to create exporter")
 
 	apiClient := getAPIClient()

--- a/cmd/iauditor-exporter/cmd/export/export.go
+++ b/cmd/iauditor-exporter/cmd/export/export.go
@@ -181,8 +181,9 @@ func runInspectionReports(cmd *cobra.Command, args []string) error {
 
 	format := viper.GetStringSlice("report.format")
 	preferenceID := viper.GetString("report.preference_id")
+	filename := viper.GetString("report.filename")
 
-	exporter, err := feed.NewReportExporter(exportPath, format, preferenceID)
+	exporter, err := feed.NewReportExporter(exportPath, format, preferenceID, filename)
 	util.Check(err, "unable to create exporter")
 
 	apiClient := getAPIClient()

--- a/cmd/iauditor-exporter/cmd/root.go
+++ b/cmd/iauditor-exporter/cmd/root.go
@@ -124,6 +124,7 @@ func configFlags() {
 
 	reportFlags = flag.NewFlagSet("report", flag.ContinueOnError)
 	reportFlags.StringSlice("format", []string{"PDF"}, "Export format (PDF,WORD)")
+	reportFlags.String("filename", "TITLE", "The name of the report exported, either TITLE or ID")
 	reportFlags.String("preference-id", "", "The report preference to apply to the document")
 
 	sitesFlags = flag.NewFlagSet("sites", flag.ContinueOnError)
@@ -159,6 +160,7 @@ func bindFlags() {
 	util.Check(viper.BindPFlag("export.site.include_deleted", sitesFlags.Lookup("site-include-deleted")), "while binding flag")
 
 	util.Check(viper.BindPFlag("report.format", reportFlags.Lookup("format")), "while binding flag")
+	util.Check(viper.BindPFlag("report.filename", reportFlags.Lookup("filename")), "while binding flag")
 	util.Check(viper.BindPFlag("report.preference_id", reportFlags.Lookup("preference-id")), "while binding flag")
 }
 

--- a/cmd/iauditor-exporter/cmd/root.go
+++ b/cmd/iauditor-exporter/cmd/root.go
@@ -124,7 +124,7 @@ func configFlags() {
 
 	reportFlags = flag.NewFlagSet("report", flag.ContinueOnError)
 	reportFlags.StringSlice("format", []string{"PDF"}, "Export format (PDF,WORD)")
-	reportFlags.String("filename", "TITLE", "The name of the report exported, either TITLE or ID")
+	reportFlags.String("filename_convention", "INSPECTION_TITLE", "The name of the report exported, either INSPECTION_TITLE or INSPECTION_ID")
 	reportFlags.String("preference-id", "", "The report preference to apply to the document")
 
 	sitesFlags = flag.NewFlagSet("sites", flag.ContinueOnError)

--- a/internal/app/feed/exporter_report.go
+++ b/internal/app/feed/exporter_report.go
@@ -234,7 +234,7 @@ func (e *ReportExporter) exportInspection(ctx context.Context, apiClient *api.Cl
 			// only allow one process to access disk at the same time
 			// this way we won't allow process to overwrite reports with the same name
 			e.Mu.Lock()
-			err = saveReportResponse(resp, inspection, e.ExportPath, format, e.Filename)
+			err = e.saveReportResponse(resp, inspection, format)
 			e.Mu.Unlock()
 			break
 		} else if rec.Status == "FAILED" {
@@ -277,8 +277,8 @@ func (e *ReportExporter) updateReportResult(rep *reportExport, res *reportExport
 	}
 }
 
-func saveReportResponse(resp io.ReadCloser, inspection *Inspection, path string, format string, filename string) error {
-	filePath, pErr := getFilePath(path, inspection, format, filename)
+func (e *ReportExporter) saveReportResponse(resp io.ReadCloser, inspection *Inspection, format string) error {
+	filePath, pErr := getFilePath(e.ExportPath, inspection, format, e.Filename)
 	if pErr != nil {
 		return pErr
 	}

--- a/internal/app/feed/exporter_report.go
+++ b/internal/app/feed/exporter_report.go
@@ -24,6 +24,7 @@ type ReportExporter struct {
 	Logger       *zap.SugaredLogger
 	ExportPath   string
 	PreferenceID string
+	Filename     string
 	Format       []string
 	Mu           sync.Mutex
 }
@@ -233,7 +234,7 @@ func (e *ReportExporter) exportInspection(ctx context.Context, apiClient *api.Cl
 			// only allow one process to access disk at the same time
 			// this way we won't allow process to overwrite reports with the same name
 			e.Mu.Lock()
-			err = saveReportResponse(resp, inspection, e.ExportPath, format)
+			err = saveReportResponse(resp, inspection, e.ExportPath, format, e.Filename)
 			e.Mu.Unlock()
 			break
 		} else if rec.Status == "FAILED" {
@@ -276,8 +277,8 @@ func (e *ReportExporter) updateReportResult(rep *reportExport, res *reportExport
 	}
 }
 
-func saveReportResponse(resp io.ReadCloser, inspection *Inspection, path string, format string) error {
-	filePath, pErr := getFilePath(path, inspection, format)
+func saveReportResponse(resp io.ReadCloser, inspection *Inspection, path string, format string, filename string) error {
+	filePath, pErr := getFilePath(path, inspection, format, filename)
 	if pErr != nil {
 		return pErr
 	}
@@ -312,11 +313,11 @@ func getFileExtension(format string) string {
 	}
 }
 
-func getFilePath(exportPath string, inspection *Inspection, format string) (string, error) {
+func getFilePath(exportPath string, inspection *Inspection, format string, filename string) (string, error) {
 	dupIndex := 0
 	for true {
 		fileName := sanitizeName(inspection.Name)
-		if strings.TrimSpace(fileName) == "" {
+		if strings.TrimSpace(fileName) == "" || filename == "ID" {
 			fileName = inspection.ID
 		}
 
@@ -346,7 +347,7 @@ func getFilePath(exportPath string, inspection *Inspection, format string) (stri
 }
 
 // NewReportExporter returns a new instance of ReportExporter
-func NewReportExporter(exportPath string, format []string, preferenceID string) (*ReportExporter, error) {
+func NewReportExporter(exportPath string, format []string, preferenceID string, filename string) (*ReportExporter, error) {
 	sqlExporter, err := NewSQLExporter("sqlite", filepath.Join(exportPath, "reports.db"), true, "")
 	if err != nil {
 		return nil, err
@@ -358,5 +359,6 @@ func NewReportExporter(exportPath string, format []string, preferenceID string) 
 		ExportPath:   exportPath,
 		Format:       format,
 		PreferenceID: preferenceID,
+		Filename:     filename,
 	}, nil
 }

--- a/internal/app/feed/exporter_report.go
+++ b/internal/app/feed/exporter_report.go
@@ -313,11 +313,11 @@ func getFileExtension(format string) string {
 	}
 }
 
-func getFilePath(exportPath string, inspection *Inspection, format string, filename string) (string, error) {
+func getFilePath(exportPath string, inspection *Inspection, format string, filenameConvention string) (string, error) {
 	dupIndex := 0
 	for true {
 		fileName := sanitizeName(inspection.Name)
-		if strings.TrimSpace(fileName) == "" || filename == "ID" {
+		if strings.TrimSpace(fileName) == "" || filenameConvention == "INSPECTION_ID" {
 			fileName = inspection.ID
 		}
 

--- a/internal/app/feed/exporter_report_test.go
+++ b/internal/app/feed/exporter_report_test.go
@@ -27,7 +27,7 @@ func getReportExportCompletionMessage(status string) string {
 }
 
 func TestExportReports_should_export_all_reports(t *testing.T) {
-	exporter, err := getTemporaryReportExporter([]string{"PDF", "WORD"}, "", "TITLE")
+	exporter, err := getTemporaryReportExporter([]string{"PDF", "WORD"}, "", "INSPECTION_TITLE")
 	assert.Nil(t, err)
 
 	viperConfig := viper.New()
@@ -67,7 +67,7 @@ func TestExportReports_should_export_all_reports(t *testing.T) {
 }
 
 func TestExportReports_should_export_all_reports_with_ID_filename(t *testing.T) {
-	exporter, err := getTemporaryReportExporter([]string{"PDF", "WORD"}, "", "ID")
+	exporter, err := getTemporaryReportExporter([]string{"PDF", "WORD"}, "", "INSPECTION_ID")
 	assert.Nil(t, err)
 
 	viperConfig := viper.New()
@@ -107,7 +107,7 @@ func TestExportReports_should_export_all_reports_with_ID_filename(t *testing.T) 
 }
 
 func TestExportReports_should_not_run_if_all_exported(t *testing.T) {
-	exporter, err := getTemporaryReportExporter([]string{"PDF"}, "", "TITLE")
+	exporter, err := getTemporaryReportExporter([]string{"PDF"}, "", "INSPECTION_TITLE")
 	assert.Nil(t, err)
 
 	viperConfig := viper.New()
@@ -158,7 +158,7 @@ func TestExportReports_should_not_run_if_all_exported(t *testing.T) {
 }
 
 func TestExportReports_should_take_care_of_invalid_file_names(t *testing.T) {
-	exporter, err := getTemporaryReportExporter([]string{"PDF"}, "", "TITLE")
+	exporter, err := getTemporaryReportExporter([]string{"PDF"}, "", "INSPECTION_TITLE")
 	assert.Nil(t, err)
 
 	viperConfig := viper.New()
@@ -207,7 +207,7 @@ func TestExportReports_should_take_care_of_invalid_file_names(t *testing.T) {
 }
 
 func TestExportReports_should_fail_after_retries(t *testing.T) {
-	exporter, err := getTemporaryReportExporter([]string{"PDF"}, "", "TITLE")
+	exporter, err := getTemporaryReportExporter([]string{"PDF"}, "", "INSPECTION_TITLE")
 	assert.Nil(t, err)
 
 	viperConfig := viper.New()
@@ -235,7 +235,7 @@ func TestExportReports_should_fail_after_retries(t *testing.T) {
 }
 
 func TestExportReports_should_fail_if_report_status_fails(t *testing.T) {
-	exporter, err := getTemporaryReportExporter([]string{"WORD"}, "", "TITLE")
+	exporter, err := getTemporaryReportExporter([]string{"WORD"}, "", "INSPECTION_TITLE")
 	assert.Nil(t, err)
 
 	viperConfig := viper.New()
@@ -262,7 +262,7 @@ func TestExportReports_should_fail_if_report_status_fails(t *testing.T) {
 }
 
 func TestExportReports_should_fail_if_init_report_reply_is_not_success(t *testing.T) {
-	exporter, err := getTemporaryReportExporter([]string{"WORD"}, "", "TITLE")
+	exporter, err := getTemporaryReportExporter([]string{"WORD"}, "", "INSPECTION_TITLE")
 	assert.Nil(t, err)
 
 	viperConfig := viper.New()
@@ -283,7 +283,7 @@ func TestExportReports_should_fail_if_init_report_reply_is_not_success(t *testin
 }
 
 func TestExportReports_should_fail_if_report_completion_reply_is_not_success(t *testing.T) {
-	exporter, err := getTemporaryReportExporter([]string{"WORD"}, "", "TITLE")
+	exporter, err := getTemporaryReportExporter([]string{"WORD"}, "", "INSPECTION_TITLE")
 	assert.Nil(t, err)
 
 	viperConfig := viper.New()
@@ -310,7 +310,7 @@ func TestExportReports_should_fail_if_report_completion_reply_is_not_success(t *
 }
 
 func TestExportReports_should_fail_if_download_report_reply_is_not_success(t *testing.T) {
-	exporter, err := getTemporaryReportExporter([]string{"PDF"}, "", "TITLE")
+	exporter, err := getTemporaryReportExporter([]string{"PDF"}, "", "INSPECTION_TITLE")
 	assert.Nil(t, err)
 
 	viperConfig := viper.New()
@@ -343,7 +343,7 @@ func TestExportReports_should_fail_if_download_report_reply_is_not_success(t *te
 }
 
 func TestExportReports_should_return_error_for_unsupported_format(t *testing.T) {
-	exporter, err := getTemporaryReportExporter([]string{"PNG"}, "", "TITLE")
+	exporter, err := getTemporaryReportExporter([]string{"PNG"}, "", "INSPECTION_TITLE")
 	assert.Nil(t, err)
 
 	viperConfig := viper.New()

--- a/internal/app/feed/utils_test.go
+++ b/internal/app/feed/utils_test.go
@@ -35,13 +35,13 @@ func getTemporaryCSVExporter() (*feed.CSVExporter, error) {
 }
 
 // getTemporaryReportExporter creates a ReportExporter that writes to a temp folder
-func getTemporaryReportExporter(format []string, preferenceID string) (*feed.ReportExporter, error) {
+func getTemporaryReportExporter(format []string, preferenceID string, filename string) (*feed.ReportExporter, error) {
 	dir, err := ioutil.TempDir("", "export")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	return feed.NewReportExporter(dir, format, preferenceID)
+	return feed.NewReportExporter(dir, format, preferenceID, filename)
 }
 
 // getTemporaryCSVExporterWithRealSQLExporter creates a CSV exporter that writes a temporary folder


### PR DESCRIPTION
added filename flag for the inspection report command