### PR TITLE
[INTG-1773] Smoke test for iauditor-exporter cmd

### DIFF
--- a/cmd/iauditor-exporter/cmd/configure_test.go
+++ b/cmd/iauditor-exporter/cmd/configure_test.go
@@ -1,0 +1,20 @@
+package cmd_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/SafetyCulture/iauditor-exporter/cmd/iauditor-exporter/cmd"
+)
+
+func TestCommandConfigure_should_not_throw_error(t *testing.T) {
+	b := bytes.NewBufferString("")
+	cmd.RootCmd.SetOut(b)
+	cmd.RootCmd.SetArgs([]string{"configure"})
+	cmd.Execute()
+	_, err := ioutil.ReadAll(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Add test case to make sure no errors are thrown when "iauditor-exporter configure" command is run