### PR TITLE
INTG-1840: increase slow query logging threshold

### DIFF
--- a/internal/app/feed/exporter_sql.go
+++ b/internal/app/feed/exporter_sql.go
@@ -140,7 +140,7 @@ func NewSQLExporter(dialect, connectionString string, autoMigrate bool, exportMe
 	logger := util.GetLogger()
 	gormLogger := &util.GormLogger{
 		SugaredLogger: logger,
-		SlowThreshold: time.Second,
+		SlowThreshold: 30 * time.Second,
 	}
 
 	var dialector gorm.Dialector


### PR DESCRIPTION
Slow query logging threshold was set to 1 second for SQL.
Some customers experience slower times which causes lots of messages in the logs and potentially making those log files much bigger.
I have updated the threshold to 30 seconds.