### PR TITLE
INTG-1855: add indexes to improve performance

### DIFF
--- a/internal/app/feed/feed_action.go
+++ b/internal/app/feed/feed_action.go
@@ -19,8 +19,8 @@ type Action struct {
 	Status          string    `json:"status" csv:"status"`
 	DueDate         time.Time `json:"due_date" csv:"due_date"`
 	CreatedAt       time.Time `json:"created_at" csv:"created_at"`
-	ModifiedAt      time.Time `json:"modified_at" csv:"modified_at"`
-	ExportedAt      time.Time `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
+	ModifiedAt      time.Time `json:"modified_at" csv:"modified_at" gorm:"index:idx_act_modified_at,sort:desc"`
+	ExportedAt      time.Time `json:"exported_at" csv:"exported_at" gorm:"index:idx_act_modified_at;autoUpdateTime"`
 	CreatorUserID   string    `json:"creator_user_id" csv:"creator_user_id"`
 	CreatorUserName string    `json:"creator_user_name" csv:"creator_user_name"`
 	TemplateID      string    `json:"template_id" csv:"template_id"`

--- a/internal/app/feed/feed_action_assignees.go
+++ b/internal/app/feed/feed_action_assignees.go
@@ -16,8 +16,8 @@ type ActionAssignee struct {
 	AssigneeID string    `json:"assignee_id" csv:"assignee_id"`
 	Type       string    `json:"type" csv:"type"`
 	Name       string    `json:"name" csv:"name"`
-	ModifiedAt time.Time `json:"modified_at" csv:"modified_at"`
-	ExportedAt time.Time `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
+	ModifiedAt time.Time `json:"modified_at" csv:"modified_at" gorm:"index:idx_act_asg_modified_at,sort:desc"`
+	ExportedAt time.Time `json:"exported_at" csv:"exported_at" gorm:"index:idx_act_asg_modified_at;autoUpdateTime"`
 }
 
 // ActionAssigneeFeed is a representation of the action_assignees feed

--- a/internal/app/feed/feed_inspection.go
+++ b/internal/app/feed/feed_inspection.go
@@ -30,8 +30,8 @@ type Inspection struct {
 	DateCompleted   *time.Time `json:"date_completed" csv:"date_completed"`
 	DateModified    time.Time  `json:"date_modified" csv:"date_modified"`
 	CreatedAt       time.Time  `json:"created_at" csv:"created_at"`
-	ModifiedAt      time.Time  `json:"modified_at" csv:"modified_at"`
-	ExportedAt      time.Time  `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
+	ModifiedAt      time.Time  `json:"modified_at" csv:"modified_at" gorm:"index:idx_ins_modified_at,sort:desc"`
+	ExportedAt      time.Time  `json:"exported_at" csv:"exported_at" gorm:"index:idx_ins_modified_at;autoUpdateTime"`
 	DocumentNo      string     `json:"document_no" csv:"document_no"`
 	PreparedBy      string     `json:"prepared_by" csv:"prepared_by"`
 	Location        string     `json:"location" csv:"location"`

--- a/internal/app/feed/feed_inspection_item.go
+++ b/internal/app/feed/feed_inspection_item.go
@@ -23,8 +23,8 @@ type InspectionItem struct {
 	TemplateID              string    `json:"template_id" csv:"template_id"`
 	ParentID                string    `json:"parent_id" csv:"parent_id"`
 	CreatedAt               time.Time `json:"created_at" csv:"created_at"`
-	ModifiedAt              time.Time `json:"modified_at" csv:"modified_at"`
-	ExportedAt              time.Time `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
+	ModifiedAt              time.Time `json:"modified_at" csv:"modified_at" gorm:"index:idx_ins_itm_modified_at,sort:desc"`
+	ExportedAt              time.Time `json:"exported_at" csv:"exported_at" gorm:"index:idx_ins_itm_modified_at;autoUpdateTime"`
 	Type                    string    `json:"type" csv:"type"`
 	Category                string    `json:"category" csv:"category"`
 	CategoryID              string    `json:"category_id" csv:"category_id"`

--- a/internal/app/feed/feed_template.go
+++ b/internal/app/feed/feed_template.go
@@ -20,8 +20,8 @@ type Template struct {
 	AuthorName  string    `json:"author_name" csv:"author_name"`
 	AuthorID    string    `json:"author_id" csv:"author_id"`
 	CreatedAt   time.Time `json:"created_at" csv:"created_at"`
-	ModifiedAt  time.Time `json:"modified_at" csv:"modified_at"`
-	ExportedAt  time.Time `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
+	ModifiedAt  time.Time `json:"modified_at" csv:"modified_at" gorm:"index:idx_tml_modified_at,sort:desc"`
+	ExportedAt  time.Time `json:"exported_at" csv:"exported_at" gorm:"index:idx_tml_modified_at;autoUpdateTime"`
 }
 
 // TemplateFeed is a representation of the templates feed


### PR DESCRIPTION
When starting the export we read the last `modified_at` value from related table. In situations that there is a large amount of data in those tables, this process can take some time to complete.
These indexes will greatly improve the performance of the query that reads `modified_at`.