### PR TITLE
INTG-1841: add max row per file flag for csv

### DIFF
--- a/cmd/iauditor-exporter/cmd/export/export.go
+++ b/cmd/iauditor-exporter/cmd/export/export.go
@@ -154,7 +154,9 @@ func runCSV(cmd *cobra.Command, args []string) error {
 		util.Check(err, fmt.Sprintf("Failed to create directory %s", exportMediaPath))
 	}
 
-	exporter, err := feed.NewCSVExporter(exportPath, exportMediaPath)
+	maxRowsPerFile := viper.GetInt("csv.max_rows_per_file")
+
+	exporter, err := feed.NewCSVExporter(exportPath, exportMediaPath, maxRowsPerFile)
 	util.Check(err, "unable to create exporter")
 
 	if viper.GetBool("export.schema_only") {

--- a/cmd/iauditor-exporter/cmd/root.go
+++ b/cmd/iauditor-exporter/cmd/root.go
@@ -19,7 +19,8 @@ import (
 )
 
 var cfgFile string
-var connectionFlags, dbFlags, exportFlags, mediaFlags, inspectionFlags, templatesFlag, tablesFlag, schemasFlag, reportFlags, sitesFlags *flag.FlagSet
+var connectionFlags, dbFlags, csvFlags, exportFlags, mediaFlags, inspectionFlags,
+	templatesFlag, tablesFlag, schemasFlag, reportFlags, sitesFlags *flag.FlagSet
 
 // RootCmd represents the base command when called without any subcommands.
 var RootCmd = &cobra.Command{
@@ -72,7 +73,7 @@ func init() {
 
 	// Add sub-commands
 	addCmd(export.SQLCmd(), connectionFlags, exportFlags, dbFlags, inspectionFlags, templatesFlag, tablesFlag, schemasFlag, mediaFlags, sitesFlags)
-	addCmd(export.CSVCmd(), connectionFlags, exportFlags, inspectionFlags, templatesFlag, tablesFlag, schemasFlag, mediaFlags, sitesFlags)
+	addCmd(export.CSVCmd(), connectionFlags, exportFlags, csvFlags, inspectionFlags, templatesFlag, tablesFlag, schemasFlag, mediaFlags, sitesFlags)
 	addCmd(export.InspectionJSONCmd(), exportFlags, connectionFlags, inspectionFlags, templatesFlag)
 	addCmd(export.ReportCmd(), connectionFlags, exportFlags, inspectionFlags, templatesFlag, reportFlags)
 	addCmd(export.PrintSchemaCmd())
@@ -96,6 +97,9 @@ func configFlags() {
 	dbFlags = flag.NewFlagSet("db", flag.ContinueOnError)
 	dbFlags.String("db-dialect", "mysql", "Database dialect. mysql, postgres and sqlserver are the only valid options.")
 	dbFlags.String("db-connection-string", "", "Database connection string")
+
+	csvFlags = flag.NewFlagSet("csv", flag.ContinueOnError)
+	csvFlags.Int("max-rows-per-file", 1000000, "Maximum number of rows in a csv file. New files will be created when reaching this limit.")
 
 	exportFlags = flag.NewFlagSet("export", flag.ContinueOnError)
 	exportFlags.String("export-path", "./export/", "File Export Path")
@@ -141,6 +145,8 @@ func bindFlags() {
 
 	util.Check(viper.BindPFlag("db.dialect", dbFlags.Lookup("db-dialect")), "while binding flag")
 	util.Check(viper.BindPFlag("db.connection_string", dbFlags.Lookup("db-connection-string")), "while binding flag")
+
+	util.Check(viper.BindPFlag("csv.max_rows_per_file", csvFlags.Lookup("max-rows-per-file")), "while binding flag")
 
 	util.Check(viper.BindPFlag("export.path", exportFlags.Lookup("export-path")), "while binding flag")
 	util.Check(viper.BindPFlag("export.incremental", exportFlags.Lookup("incremental")), "while binding flag")

--- a/internal/app/feed/exporter_csv_test.go
+++ b/internal/app/feed/exporter_csv_test.go
@@ -387,7 +387,6 @@ func TestCSVExporterFinaliseExport_should_write_rows_to_multiple_file(t *testing
 	assert.Nil(t, err)
 
 	content1String := dateRegex.ReplaceAllLiteralString(strings.TrimSpace(string(content1)), "--date--")
-
 	expected1 := `user_id,organisation_id,email,firstname,lastname,active,exported_at
 user_1,role_123,user.1@test.com,User 1,User 1,false,--date--
 user_2,role_123,user.2@test.com,User 2,User 2,false,--date--`
@@ -397,7 +396,6 @@ user_2,role_123,user.2@test.com,User 2,User 2,false,--date--`
 	assert.Nil(t, err)
 
 	content2String := dateRegex.ReplaceAllLiteralString(strings.TrimSpace(string(content2)), "--date--")
-
 	expected2 := `user_id,organisation_id,email,firstname,lastname,active,exported_at
 user_3,role_123,user.3@test.com,User 3,User 3,false,--date--`
 	assert.Equal(t, strings.TrimSpace(expected2), content2String)

--- a/internal/app/feed/exporter_csv_test.go
+++ b/internal/app/feed/exporter_csv_test.go
@@ -387,6 +387,7 @@ func TestCSVExporterFinaliseExport_should_write_rows_to_multiple_file(t *testing
 	assert.Nil(t, err)
 
 	content1String := dateRegex.ReplaceAllLiteralString(strings.TrimSpace(string(content1)), "--date--")
+
 	expected1 := `user_id,organisation_id,email,firstname,lastname,active,exported_at
 user_1,role_123,user.1@test.com,User 1,User 1,false,--date--
 user_2,role_123,user.2@test.com,User 2,User 2,false,--date--`
@@ -396,6 +397,7 @@ user_2,role_123,user.2@test.com,User 2,User 2,false,--date--`
 	assert.Nil(t, err)
 
 	content2String := dateRegex.ReplaceAllLiteralString(strings.TrimSpace(string(content2)), "--date--")
+
 	expected2 := `user_id,organisation_id,email,firstname,lastname,active,exported_at
 user_3,role_123,user.3@test.com,User 3,User 3,false,--date--`
 	assert.Equal(t, strings.TrimSpace(expected2), content2String)

--- a/internal/app/feed/utils_test.go
+++ b/internal/app/feed/utils_test.go
@@ -34,7 +34,7 @@ func getTemporaryCSVExporter() (*feed.CSVExporter, error) {
 	return feed.NewCSVExporter(dir, "", 100000)
 }
 
-// getTemporaryCSVExporterWithMaxRowsLimit creates a CSVExporter that writes to a temp folder
+// getTemporaryCSVExporterWithMaxRowsLimit creates a CSVExporter that writes to a temp folder with row limit
 func getTemporaryCSVExporterWithMaxRowsLimit(maxRowsPerFile int) (*feed.CSVExporter, error) {
 	dir, err := ioutil.TempDir("", "export")
 	if err != nil {

--- a/internal/app/feed/utils_test.go
+++ b/internal/app/feed/utils_test.go
@@ -31,7 +31,7 @@ func getTemporaryCSVExporter() (*feed.CSVExporter, error) {
 		log.Fatal(err)
 	}
 
-	return feed.NewCSVExporter(dir, "")
+	return feed.NewCSVExporter(dir, "", 100000)
 }
 
 // getTemporaryReportExporter creates a ReportExporter that writes to a temp folder
@@ -52,7 +52,7 @@ func getTemporaryCSVExporterWithRealSQLExporter(sqlExporter *feed.SQLExporter) (
 		return nil, err
 	}
 
-	exporter, err := feed.NewCSVExporter(dir, "")
+	exporter, err := feed.NewCSVExporter(dir, "", 100000)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/feed/utils_test.go
+++ b/internal/app/feed/utils_test.go
@@ -34,6 +34,16 @@ func getTemporaryCSVExporter() (*feed.CSVExporter, error) {
 	return feed.NewCSVExporter(dir, "", 100000)
 }
 
+// getTemporaryCSVExporterWithMaxRowsLimit creates a CSVExporter that writes to a temp folder
+func getTemporaryCSVExporterWithMaxRowsLimit(maxRowsPerFile int) (*feed.CSVExporter, error) {
+	dir, err := ioutil.TempDir("", "export")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return feed.NewCSVExporter(dir, "", maxRowsPerFile)
+}
+
 // getTemporaryReportExporter creates a ReportExporter that writes to a temp folder
 func getTemporaryReportExporter(format []string, preferenceID string, filename string) (*feed.ReportExporter, error) {
 	dir, err := ioutil.TempDir("", "export")


### PR DESCRIPTION
- Introduced a new flag for `csv` export called `--max-rows-per-file` with the default value of `1000000`
- Cleanup all `csv` files for a feed before saving new files
- If  limit is reached, current file will be renamed to `feedName_20060102150405.999999.csv` and a new `feedName.csv` will be created
- The coverage is at `82%`. The code paths that are not covered are related to file system errors which I'm not sure how to test.