### PR TITLE
INTG-1867: make columns fixed size

### DIFF
--- a/internal/app/feed/feed_action.go
+++ b/internal/app/feed/feed_action.go
@@ -24,7 +24,7 @@ type Action struct {
 	CreatorUserID   string    `json:"creator_user_id" csv:"creator_user_id" gorm:"size:37"`
 	CreatorUserName string    `json:"creator_user_name" csv:"creator_user_name"`
 	TemplateID      string    `json:"template_id" csv:"template_id" gorm:"size:100"`
-	AuditID         string    `json:"audit_id" csv:"audit_id" gorm:"size:38"`
+	AuditID         string    `json:"audit_id" csv:"audit_id" gorm:"size:100"`
 	AuditTitle      string    `json:"audit_title" csv:"audit_title"`
 	AuditItemID     string    `json:"audit_item_id" csv:"audit_item_id" gorm:"size:100"`
 	AuditItemLabel  string    `json:"audit_item_label" csv:"audit_item_label"`

--- a/internal/app/feed/feed_action.go
+++ b/internal/app/feed/feed_action.go
@@ -11,24 +11,24 @@ import (
 
 // Action represents a row from the actions feed
 type Action struct {
-	ID              string    `json:"id" csv:"action_id" gorm:"primarykey;column:action_id"`
+	ID              string    `json:"id" csv:"action_id" gorm:"primarykey;column:action_id;size:36"`
 	Title           string    `json:"title" csv:"title"`
 	Description     string    `json:"description" csv:"description"`
-	SiteID          string    `json:"site_id" csv:"site_id"`
-	Priority        string    `json:"priority" csv:"priority"`
-	Status          string    `json:"status" csv:"status"`
+	SiteID          string    `json:"site_id" csv:"site_id" gorm:"size:41"`
+	Priority        string    `json:"priority" csv:"priority" gorm:"size:20"`
+	Status          string    `json:"status" csv:"status" gorm:"size:20"`
 	DueDate         time.Time `json:"due_date" csv:"due_date"`
 	CreatedAt       time.Time `json:"created_at" csv:"created_at"`
 	ModifiedAt      time.Time `json:"modified_at" csv:"modified_at" gorm:"index:idx_act_modified_at,sort:desc"`
 	ExportedAt      time.Time `json:"exported_at" csv:"exported_at" gorm:"index:idx_act_modified_at;autoUpdateTime"`
-	CreatorUserID   string    `json:"creator_user_id" csv:"creator_user_id"`
+	CreatorUserID   string    `json:"creator_user_id" csv:"creator_user_id" gorm:"size:37"`
 	CreatorUserName string    `json:"creator_user_name" csv:"creator_user_name"`
-	TemplateID      string    `json:"template_id" csv:"template_id"`
-	AuditID         string    `json:"audit_id" csv:"audit_id"`
+	TemplateID      string    `json:"template_id" csv:"template_id" gorm:"size:100"`
+	AuditID         string    `json:"audit_id" csv:"audit_id" gorm:"size:38"`
 	AuditTitle      string    `json:"audit_title" csv:"audit_title"`
-	AuditItemID     string    `json:"audit_item_id" csv:"audit_item_id"`
+	AuditItemID     string    `json:"audit_item_id" csv:"audit_item_id" gorm:"size:100"`
 	AuditItemLabel  string    `json:"audit_item_label" csv:"audit_item_label"`
-	OrganisationID  string    `json:"organisation_id" csv:"organisation_id" gorm:"index:idx_act_modified_at"`
+	OrganisationID  string    `json:"organisation_id" csv:"organisation_id" gorm:"index:idx_act_modified_at;size:37"`
 }
 
 // ActionFeed is a representation of the actions feed

--- a/internal/app/feed/feed_action_assignees.go
+++ b/internal/app/feed/feed_action_assignees.go
@@ -11,12 +11,12 @@ import (
 
 // ActionAssignee represents a row from the action_assignees feed
 type ActionAssignee struct {
-	ID             string    `json:"id" csv:"id" gorm:"primarykey"`
-	ActionID       string    `json:"action_id" csv:"action_id"`
-	AssigneeID     string    `json:"assignee_id" csv:"assignee_id"`
-	Type           string    `json:"type" csv:"type"`
+	ID             string    `json:"id" csv:"id" gorm:"primarykey;size:375"`
+	ActionID       string    `json:"action_id" csv:"action_id" gorm:"size:36"`
+	AssigneeID     string    `json:"assignee_id" csv:"assignee_id" gorm:"size:256"`
+	Type           string    `json:"type" csv:"type" gorm:"size:10"`
 	Name           string    `json:"name" csv:"name"`
-	OrganisationID string    `json:"organisation_id" csv:"organisation_id" gorm:"index:idx_act_asg_modified_at"`
+	OrganisationID string    `json:"organisation_id" csv:"organisation_id" gorm:"index:idx_act_asg_modified_at;size:37"`
 	ModifiedAt     time.Time `json:"modified_at" csv:"modified_at" gorm:"index:idx_act_asg_modified_at,sort:desc"`
 	ExportedAt     time.Time `json:"exported_at" csv:"exported_at" gorm:"index:idx_act_asg_modified_at;autoUpdateTime"`
 }

--- a/internal/app/feed/feed_group.go
+++ b/internal/app/feed/feed_group.go
@@ -11,9 +11,9 @@ import (
 
 // Group represents a row from the groups feed
 type Group struct {
-	ID             string    `json:"id" csv:"group_id" gorm:"primarykey;column:group_id"`
+	ID             string    `json:"id" csv:"group_id" gorm:"primarykey;column:group_id;size:37"`
 	Name           string    `json:"name" csv:"name"`
-	OrganisationID string    `json:"organisation_id" csv:"organisation_id"`
+	OrganisationID string    `json:"organisation_id" csv:"organisation_id" gorm:"size:37"`
 	ExportedAt     time.Time `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
 }
 

--- a/internal/app/feed/feed_group_user.go
+++ b/internal/app/feed/feed_group_user.go
@@ -11,9 +11,9 @@ import (
 
 // GroupUser represents a row from the group_users feed
 type GroupUser struct {
-	UserID         string    `json:"user_id" csv:"user_id" gorm:"primaryKey"`
-	GroupID        string    `json:"group_id" csv:"group_id" gorm:"primaryKey"`
-	OrganisationID string    `json:"organisation_id" csv:"organisation_id"`
+	UserID         string    `json:"user_id" csv:"user_id" gorm:"primaryKey;size:37"`
+	GroupID        string    `json:"group_id" csv:"group_id" gorm:"primaryKey;size:37"`
+	OrganisationID string    `json:"organisation_id" csv:"organisation_id" gorm:"size:37"`
 	ExportedAt     time.Time `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
 }
 

--- a/internal/app/feed/feed_inspection.go
+++ b/internal/app/feed/feed_inspection.go
@@ -11,22 +11,22 @@ import (
 
 // Inspection represents a row from the inspections feed
 type Inspection struct {
-	ID              string     `json:"id" csv:"audit_id" gorm:"primarykey;column:audit_id"`
+	ID              string     `json:"id" csv:"audit_id" gorm:"primarykey;column:audit_id;size:38"`
 	Name            string     `json:"name" csv:"name"`
 	Archived        bool       `json:"archived" csv:"archived"`
 	OwnerName       string     `json:"owner_name" csv:"owner_name"`
-	OwnerID         string     `json:"owner_id" csv:"owner_id"`
+	OwnerID         string     `json:"owner_id" csv:"owner_id" gorm:"size:37"`
 	AuthorName      string     `json:"author_name" csv:"author_name"`
-	AuthorID        string     `json:"author_id" csv:"author_id"`
+	AuthorID        string     `json:"author_id" csv:"author_id" gorm:"size:37"`
 	Score           float32    `json:"score" csv:"score"`
 	MaxScore        float32    `json:"max_score" csv:"max_score"`
 	ScorePercentage float32    `json:"score_percentage" csv:"score_percentage"`
 	Duration        int64      `json:"duration" csv:"duration"`
-	TemplateID      string     `json:"template_id" csv:"template_id"`
-	OrganisationID  string     `json:"organisation_id" csv:"organisation_id" gorm:"index:idx_ins_modified_at"`
+	TemplateID      string     `json:"template_id" csv:"template_id" gorm:"size:100"`
+	OrganisationID  string     `json:"organisation_id" csv:"organisation_id" gorm:"index:idx_ins_modified_at;size:37"`
 	TemplateName    string     `json:"template_name" csv:"template_name"`
 	TemplateAuthor  string     `json:"template_author" csv:"template_author"`
-	SiteID          string     `json:"site_id" csv:"site_id"`
+	SiteID          string     `json:"site_id" csv:"site_id" gorm:"size:41"`
 	DateStarted     time.Time  `json:"date_started" csv:"date_started"`
 	DateCompleted   *time.Time `json:"date_completed" csv:"date_completed"`
 	DateModified    time.Time  `json:"date_modified" csv:"date_modified"`

--- a/internal/app/feed/feed_inspection.go
+++ b/internal/app/feed/feed_inspection.go
@@ -11,7 +11,7 @@ import (
 
 // Inspection represents a row from the inspections feed
 type Inspection struct {
-	ID              string     `json:"id" csv:"audit_id" gorm:"primarykey;column:audit_id;size:38"`
+	ID              string     `json:"id" csv:"audit_id" gorm:"primarykey;column:audit_id;size:100"`
 	Name            string     `json:"name" csv:"name"`
 	Archived        bool       `json:"archived" csv:"archived"`
 	OwnerName       string     `json:"owner_name" csv:"owner_name"`

--- a/internal/app/feed/feed_inspection_item.go
+++ b/internal/app/feed/feed_inspection_item.go
@@ -16,24 +16,24 @@ const maxGoRoutines = 10
 
 // InspectionItem represents a row from the inspection_items feed
 type InspectionItem struct {
-	ID                      string    `json:"id" csv:"id" gorm:"primarykey"`
-	ItemID                  string    `json:"item_id" csv:"item_id"`
-	AuditID                 string    `json:"audit_id" csv:"audit_id"`
+	ID                      string    `json:"id" csv:"id" gorm:"primarykey;size:150"`
+	ItemID                  string    `json:"item_id" csv:"item_id" gorm:"size:100"`
+	AuditID                 string    `json:"audit_id" csv:"audit_id" gorm:"size:38"`
 	ItemIndex               int64     `json:"item_index" csv:"item_index"`
-	TemplateID              string    `json:"template_id" csv:"template_id"`
-	ParentID                string    `json:"parent_id" csv:"parent_id"`
+	TemplateID              string    `json:"template_id" csv:"template_id" gorm:"size:100"`
+	ParentID                string    `json:"parent_id" csv:"parent_id" gorm:"size:100"`
 	CreatedAt               time.Time `json:"created_at" csv:"created_at"`
 	ModifiedAt              time.Time `json:"modified_at" csv:"modified_at" gorm:"index:idx_ins_itm_modified_at,sort:desc"`
 	ExportedAt              time.Time `json:"exported_at" csv:"exported_at" gorm:"index:idx_ins_itm_modified_at;autoUpdateTime"`
-	Type                    string    `json:"type" csv:"type"`
+	Type                    string    `json:"type" csv:"type" gorm:"size:20"`
 	Category                string    `json:"category" csv:"category"`
-	CategoryID              string    `json:"category_id" csv:"category_id"`
-	OrganisationID          string    `json:"organisation_id" csv:"organisation_id" gorm:"index:idx_ins_itm_modified_at"`
+	CategoryID              string    `json:"category_id" csv:"category_id" gorm:"size:100"`
+	OrganisationID          string    `json:"organisation_id" csv:"organisation_id" gorm:"index:idx_ins_itm_modified_at;size:37"`
 	ParentIDs               string    `json:"parent_ids" csv:"parent_ids"`
 	Label                   string    `json:"label" csv:"label"`
 	Response                string    `json:"response" csv:"response"`
-	ResponseID              string    `json:"response_id" csv:"response_id"`
-	ResponseSetID           string    `json:"response_set_id" csv:"response_set_id"`
+	ResponseID              string    `json:"response_id" csv:"response_id" gorm:"size:100"`
+	ResponseSetID           string    `json:"response_set_id" csv:"response_set_id" gorm:"size:100"`
 	IsFailedResponse        bool      `json:"is_failed_response" csv:"is_failed_response"`
 	Comment                 string    `json:"comment" csv:"comment"`
 	MediaFiles              string    `json:"media_files" csv:"media_files"`

--- a/internal/app/feed/feed_inspection_item.go
+++ b/internal/app/feed/feed_inspection_item.go
@@ -18,7 +18,7 @@ const maxGoRoutines = 10
 type InspectionItem struct {
 	ID                      string    `json:"id" csv:"id" gorm:"primarykey;size:150"`
 	ItemID                  string    `json:"item_id" csv:"item_id" gorm:"size:100"`
-	AuditID                 string    `json:"audit_id" csv:"audit_id" gorm:"size:38"`
+	AuditID                 string    `json:"audit_id" csv:"audit_id" gorm:"size:100"`
 	ItemIndex               int64     `json:"item_index" csv:"item_index"`
 	TemplateID              string    `json:"template_id" csv:"template_id" gorm:"size:100"`
 	ParentID                string    `json:"parent_id" csv:"parent_id" gorm:"size:100"`

--- a/internal/app/feed/feed_schedule.go
+++ b/internal/app/feed/feed_schedule.go
@@ -11,10 +11,10 @@ import (
 
 // Schedule represents a row from the schedules feed
 type Schedule struct {
-	ID              string     `json:"id" csv:"schedule_id" gorm:"primarykey;column:schedule_id"`
+	ID              string     `json:"id" csv:"schedule_id" gorm:"primarykey;column:schedule_id;size:45"`
 	Description     string     `json:"description" csv:"description"`
-	Recurrence      string     `json:"recurrence" csv:"recurrence"`
-	Duration        string     `json:"duration" csv:"duration"`
+	Recurrence      string     `json:"recurrence" csv:"recurrence" gorm:"size:100"`
+	Duration        string     `json:"duration" csv:"duration" gorm:"size:50"`
 	ModifiedAt      time.Time  `json:"modified_at" csv:"modified_at"`
 	ExportedAt      time.Time  `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
 	FromDate        time.Time  `json:"from_date" csv:"from_date"`
@@ -22,13 +22,13 @@ type Schedule struct {
 	StartTimeHour   int        `json:"start_time_hour" csv:"start_time_hour"`
 	StartTimeMinute int        `json:"start_time_minute" csv:"start_time_minute"`
 	AllMustComplete bool       `json:"all_must_complete" csv:"all_must_complete"`
-	Status          string     `json:"status" csv:"status"`
-	OrganisationID  string     `json:"organisation_id" csv:"organisation_id"`
+	Status          string     `json:"status" csv:"status" gorm:"size:10"`
+	OrganisationID  string     `json:"organisation_id" csv:"organisation_id" gorm:"size:37"`
 	Timezone        string     `json:"timezone" csv:"timezone"`
 	CanLateSubmit   bool       `json:"can_late_submit" csv:"can_late_submit"`
-	SiteID          string     `json:"site_id" csv:"site_id"`
-	TemplateID      string     `json:"template_id" csv:"template_id"`
-	CreatorUserID   string     `json:"creator_user_id" csv:"creator_user_id"`
+	SiteID          string     `json:"site_id" csv:"site_id" gorm:"size:41"`
+	TemplateID      string     `json:"template_id" csv:"template_id" gorm:"size:100"`
+	CreatorUserID   string     `json:"creator_user_id" csv:"creator_user_id" gorm:"size:37"`
 }
 
 // ScheduleFeed is a representation of the schedules feed

--- a/internal/app/feed/feed_schedule_assginee.go
+++ b/internal/app/feed/feed_schedule_assginee.go
@@ -11,11 +11,11 @@ import (
 
 // ScheduleAssignee represents a row from the schedule_assignees feed
 type ScheduleAssignee struct {
-	ID             string    `json:"id" csv:"id" gorm:"primarykey"`
-	ScheduleID     string    `json:"schedule_id" csv:"schedule_id"`
-	AssigneeID     string    `json:"assignee_id" csv:"assignee_id"`
-	OrganisationID string    `json:"organisation_id" csv:"organisation_id"`
-	Type           string    `json:"type" csv:"type"`
+	ID             string    `json:"id" csv:"id" gorm:"primarykey;size:100"`
+	ScheduleID     string    `json:"schedule_id" csv:"schedule_id" gorm:"size:45"`
+	AssigneeID     string    `json:"assignee_id" csv:"assignee_id" gorm:"size:37"`
+	OrganisationID string    `json:"organisation_id" csv:"organisation_id" gorm:"size:37"`
+	Type           string    `json:"type" csv:"type" gorm:"size:10"`
 	Name           string    `json:"name" csv:"name"`
 	ExportedAt     time.Time `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
 }

--- a/internal/app/feed/feed_schedule_occurrence.go
+++ b/internal/app/feed/feed_schedule_occurrence.go
@@ -18,7 +18,7 @@ type ScheduleOccurrence struct {
 	OrganisationID   string     `json:"organisation_id" csv:"organisation_id" gorm:"size:37"`
 	MissTime         *time.Time `json:"miss_time" csv:"miss_time"`
 	OccurrenceStatus string     `json:"occurrence_status" csv:"occurrence_status" gorm:"size:20"`
-	AuditID          *string    `json:"audit_id" csv:"audit_id" gorm:"size:38"`
+	AuditID          *string    `json:"audit_id" csv:"audit_id" gorm:"size:100"`
 	CompletedAt      *time.Time `json:"completed_at" csv:"completed_at"`
 	ExportedAt       time.Time  `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
 	UserID           string     `json:"user_id" csv:"user_id" gorm:"size:37"`

--- a/internal/app/feed/feed_schedule_occurrence.go
+++ b/internal/app/feed/feed_schedule_occurrence.go
@@ -11,18 +11,18 @@ import (
 
 // ScheduleOccurrence represents a row from the schedule_occurrences feed
 type ScheduleOccurrence struct {
-	ID               string     `json:"id" csv:"id" gorm:"primarykey"`
-	ScheduleID       string     `json:"schedule_id" csv:"schedule_id"`
-	OccurrenceID     string     `json:"occurrence_id" csv:"occurrence_id"`
-	TemplateID       string     `json:"template_id" csv:"template_id"`
-	OrganisationID   string     `json:"organisation_id" csv:"organisation_id"`
+	ID               string     `json:"id" csv:"id" gorm:"primarykey;size:128"`
+	ScheduleID       string     `json:"schedule_id" csv:"schedule_id" gorm:"size:45"`
+	OccurrenceID     string     `json:"occurrence_id" csv:"occurrence_id" gorm:"size:30"`
+	TemplateID       string     `json:"template_id" csv:"template_id" gorm:"size:100"`
+	OrganisationID   string     `json:"organisation_id" csv:"organisation_id" gorm:"size:37"`
 	MissTime         *time.Time `json:"miss_time" csv:"miss_time"`
-	OccurrenceStatus string     `json:"occurrence_status" csv:"occurrence_status"`
-	AuditID          *string    `json:"audit_id" csv:"audit_id"`
+	OccurrenceStatus string     `json:"occurrence_status" csv:"occurrence_status" gorm:"size:20"`
+	AuditID          *string    `json:"audit_id" csv:"audit_id" gorm:"size:38"`
 	CompletedAt      *time.Time `json:"completed_at" csv:"completed_at"`
 	ExportedAt       time.Time  `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
-	UserID           string     `json:"user_id" csv:"user_id"`
-	AssigneeStatus   string     `json:"assignee_status" csv:"assignee_status"`
+	UserID           string     `json:"user_id" csv:"user_id" gorm:"size:37"`
+	AssigneeStatus   string     `json:"assignee_status" csv:"assignee_status" gorm:"size:20"`
 }
 
 // ScheduleOccurrenceFeed is a representation of the schedule_occurrences feed

--- a/internal/app/feed/feed_site.go
+++ b/internal/app/feed/feed_site.go
@@ -11,10 +11,10 @@ import (
 
 // Site represents a row from the sites feed
 type Site struct {
-	ID             string    `json:"id" csv:"site_id" gorm:"primarykey;column:site_id"`
+	ID             string    `json:"id" csv:"site_id" gorm:"primarykey;column:site_id;size:41"`
 	Name           string    `json:"name" csv:"name"`
-	CreatorID      string    `json:"creator_id" csv:"creator_id"`
-	OrganisationID string    `json:"organisation_id" csv:"organisation_id"`
+	CreatorID      string    `json:"creator_id" csv:"creator_id" gorm:"size:37"`
+	OrganisationID string    `json:"organisation_id" csv:"organisation_id" gorm:"size:37"`
 	ExportedAt     time.Time `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
 	Deleted        bool      `json:"deleted" csv:"deleted" gorm:"deleted"`
 }

--- a/internal/app/feed/feed_template.go
+++ b/internal/app/feed/feed_template.go
@@ -11,15 +11,15 @@ import (
 
 // Template represents a row from the templates feed
 type Template struct {
-	ID             string    `json:"id" csv:"template_id" gorm:"primarykey;column:template_id"`
+	ID             string    `json:"id" csv:"template_id" gorm:"primarykey;column:template_id;size:100"`
 	Archived       bool      `json:"archived" csv:"archived"`
 	Name           string    `json:"name" csv:"name"`
 	Description    string    `json:"description" csv:"description"`
-	OrganisationID string    `json:"organisation_id" csv:"organisation_id" gorm:"index:idx_tml_modified_at"`
+	OrganisationID string    `json:"organisation_id" csv:"organisation_id" gorm:"index:idx_tml_modified_at;size:37"`
 	OwnerName      string    `json:"owner_name" csv:"owner_name"`
-	OwnerID        string    `json:"owner_id" csv:"owner_id"`
+	OwnerID        string    `json:"owner_id" csv:"owner_id" gorm:"size:37"`
 	AuthorName     string    `json:"author_name" csv:"author_name"`
-	AuthorID       string    `json:"author_id" csv:"author_id"`
+	AuthorID       string    `json:"author_id" csv:"author_id" gorm:"size:37"`
 	CreatedAt      time.Time `json:"created_at" csv:"created_at"`
 	ModifiedAt     time.Time `json:"modified_at" csv:"modified_at" gorm:"index:idx_tml_modified_at,sort:desc"`
 	ExportedAt     time.Time `json:"exported_at" csv:"exported_at" gorm:"index:idx_tml_modified_at;autoUpdateTime"`

--- a/internal/app/feed/feed_template_permission.go
+++ b/internal/app/feed/feed_template_permission.go
@@ -11,12 +11,12 @@ import (
 
 // TemplatePermission represents a row from the template_permissions feed
 type TemplatePermission struct {
-	ID             string `json:"id" csv:"permission_id" gorm:"primarykey;column:permission_id"`
-	TemplateID     string `json:"template_id" csv:"template_id"`
-	Permission     string `json:"permission" csv:"permission"`
-	AssigneeID     string `json:"assignee_id" csv:"assignee_id"`
-	AssigneeType   string `json:"assignee_type" csv:"assignee_type"`
-	OrganisationID string `json:"organisation_id" csv:"organisation_id"`
+	ID             string `json:"id" csv:"permission_id" gorm:"primarykey;column:permission_id;size:375"`
+	TemplateID     string `json:"template_id" csv:"template_id" gorm:"size:100"`
+	Permission     string `json:"permission" csv:"permission" gorm:"size:10"`
+	AssigneeID     string `json:"assignee_id" csv:"assignee_id" gorm:"size:256"`
+	AssigneeType   string `json:"assignee_type" csv:"assignee_type" gorm:"size:10"`
+	OrganisationID string `json:"organisation_id" csv:"organisation_id" gorm:"size:37"`
 }
 
 // TemplatePermissionFeed is a representation of the template_permissions feed

--- a/internal/app/feed/feed_user.go
+++ b/internal/app/feed/feed_user.go
@@ -11,9 +11,9 @@ import (
 
 // User represents a row from the users feed
 type User struct {
-	ID             string    `json:"id" csv:"user_id" gorm:"primarykey;column:user_id"`
-	OrganisationID string    `json:"organisation_id" csv:"organisation_id"`
-	Email          string    `json:"email" csv:"email"`
+	ID             string    `json:"id" csv:"user_id" gorm:"primarykey;column:user_id;size:37"`
+	OrganisationID string    `json:"organisation_id" csv:"organisation_id" gorm:"size:37"`
+	Email          string    `json:"email" csv:"email" gorm:"size:256"`
 	Firstname      string    `json:"firstname" csv:"firstname"`
 	Lastname       string    `json:"lastname" csv:"lastname"`
 	Active         bool      `json:"active" csv:"active"`


### PR DESCRIPTION
When not specifying a column size `gorm` by default uses `nvarchar(max)` which causes issues when customers are trying to add indexes to those columns.
I've updated most columns to have a fixed size when possible.