### PR TITLE
[INTG-1937] Site_id from Inspections data set not updating

### DIFF
--- a/internal/app/feed/feed_action_assignees.go
+++ b/internal/app/feed/feed_action_assignees.go
@@ -55,6 +55,8 @@ func (f *ActionAssigneeFeed) Columns() []string {
 		"type",
 		"name",
 		"organisation_id",
+		"modified_at",
+		"exported_at",
 	}
 }
 

--- a/internal/app/feed/feed_inspection.go
+++ b/internal/app/feed/feed_inspection.go
@@ -93,6 +93,7 @@ func (f *InspectionFeed) Columns() []string {
 		"organisation_id",
 		"template_name",
 		"template_author",
+		"site_id",
 		"date_started",
 		"date_completed",
 		"date_modified",

--- a/internal/app/feed/feed_schedule_assginee.go
+++ b/internal/app/feed/feed_schedule_assginee.go
@@ -53,6 +53,7 @@ func (f *ScheduleAssigneeFeed) Columns() []string {
 		"organisation_id",
 		"type",
 		"name",
+		"exported_at",
 	}
 }
 

--- a/internal/app/feed/feed_site.go
+++ b/internal/app/feed/feed_site.go
@@ -51,6 +51,7 @@ func (f *SiteFeed) Columns() []string {
 		"creator_id",
 		"organisation_id",
 		"exported_at",
+		"deleted",
 	}
 }
 


### PR DESCRIPTION
For each table we specify the columns that can be updated in the corresponding feed_table.go.
If the column is missing then it only inserts and doesn't update the data. Updated those columns through this PR.