### PR TITLE
[PROBLEM-1079] fixing inner loop in actions_assignees

### DIFF
--- a/internal/app/feed/feed_action_assignee_test.go
+++ b/internal/app/feed/feed_action_assignee_test.go
@@ -1,0 +1,35 @@
+package feed_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SafetyCulture/iauditor-exporter/internal/app/feed"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/SafetyCulture/iauditor-exporter/internal/app/api"
+)
+
+func TestActionAssigneeFeedExport_should_export_rows_to_sql_db(t *testing.T) {
+	exporter, err := getInmemorySQLExporter("")
+	assert.Nil(t, err)
+
+	apiClient := api.GetTestClient()
+	initMockFeedsSet1(apiClient.HTTPClient())
+
+	actionAssigneeFeed := feed.ActionAssigneeFeed{
+		ModifiedAfter: time.Now(),
+		Incremental:   true,
+	}
+
+	err = actionAssigneeFeed.Export(context.Background(), apiClient, exporter, "")
+	assert.Nil(t, err)
+
+	rows := []feed.ActionAssignee{}
+	resp := exporter.DB.Table("action_assignees").Scan(&rows)
+	assert.Nil(t, resp.Error)
+
+	assert.Equal(t, 2, len(rows))
+	assert.Equal(t, "email@domain.com", rows[0].AssigneeID)
+}

--- a/internal/app/feed/feed_action_assignees.go
+++ b/internal/app/feed/feed_action_assignees.go
@@ -80,7 +80,7 @@ func (f *ActionAssigneeFeed) writeRows(ctx context.Context, exporter Exporter, r
 			j = len(rows)
 		}
 		var actionIDs []string
-		for k := i; k < (i+j) || k < len(rows); k++ {
+		for k := range rows[i:j] {
 			actionIDs = append(actionIDs, rows[k].ActionID)
 		}
 

--- a/internal/app/feed/feed_action_assignees.go
+++ b/internal/app/feed/feed_action_assignees.go
@@ -80,7 +80,7 @@ func (f *ActionAssigneeFeed) writeRows(ctx context.Context, exporter Exporter, r
 			j = len(rows)
 		}
 		var actionIDs []string
-		for k := i; k < (i + j); k++ {
+		for k := i; k < (i+j) || k < len(rows); k++ {
 			actionIDs = append(actionIDs, rows[k].ActionID)
 		}
 


### PR DESCRIPTION
It looks like the inner loop when fetching the `actionID` for each row would overflow when `i+j` would exceed `len(rows)`. Adding a secondary check for the row array length to avoid this.