### PR TITLE
[KB-1787] Rename "Preference" to "Layout" in other product areas

### DIFF
--- a/cmd/iauditor-exporter/cmd/export/export.go
+++ b/cmd/iauditor-exporter/cmd/export/export.go
@@ -74,7 +74,7 @@ func ReportCmd() *cobra.Command {
 		Short: "Export inspection report",
 		Example: `// Export PDF and Word inspection reports
 		iauditor-exporter report --export-path /path/to/export/to --format PDF,WORD
-		// Export PDF inspection reports with a custom report preference
+		// Export PDF inspection reports with a custom report layout
 		iauditor-exporter report --export-path /path/to/export/to --format PDF --preference-id abc`,
 		RunE: runInspectionReports,
 	}

--- a/cmd/iauditor-exporter/cmd/root.go
+++ b/cmd/iauditor-exporter/cmd/root.go
@@ -133,7 +133,7 @@ func configFlags() {
 	reportFlags = flag.NewFlagSet("report", flag.ContinueOnError)
 	reportFlags.StringSlice("format", []string{"PDF"}, "Export format (PDF,WORD)")
 	reportFlags.String("filename-convention", "INSPECTION_TITLE", "The name of the report exported, either INSPECTION_TITLE or INSPECTION_ID")
-	reportFlags.String("preference-id", "", "The report preference to apply to the document")
+	reportFlags.String("preference-id", "", "The report layout to apply to the document")
 	reportFlags.Int("retry-timeout", 15, "Specify the time in seconds spent retrieving each report. Values greater than 60 seconds will be treated as 60 seconds.")
 
 	sitesFlags = flag.NewFlagSet("sites", flag.ContinueOnError)

--- a/docs/iauditor-exporter_report.md
+++ b/docs/iauditor-exporter_report.md
@@ -11,7 +11,7 @@ iauditor-exporter report [flags]
 ```
 // Export PDF and Word inspection reports
 		iauditor-exporter report --export-path /path/to/export/to --format PDF,WORD
-		// Export PDF inspection reports with a custom report preference
+		// Export PDF inspection reports with a custom report layout
 		iauditor-exporter report --export-path /path/to/export/to --format PDF --preference-id abc
 ```
 
@@ -33,7 +33,7 @@ iauditor-exporter report [flags]
       --inspection-skip-ids strings         Skip storing these inspection IDs
       --inspection-web-report-link string   Web report link format. Can be public or private (default "private")
       --modified-after string               Return inspections modified after this date (see readme for supported formats)
-      --preference-id string                The report preference to apply to the document
+      --preference-id string                The report layout to apply to the document
       --proxy-url string                    Proxy URL for making API requests through
       --retry-timeout int                   Specify the time in seconds spent retrieving each report. Values greater than 60 seconds will be treated as 60 seconds. (default 15)
       --template-ids strings                Template IDs to filter inspections and schedules by (default all)


### PR DESCRIPTION
The "report preference" feature is being renamed to "report layout". Beyond our support articles, we also need to update other product areas to use the new feature name.