### PR TITLE
Skip coverage on dependabot PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,6 +180,7 @@ jobs:
 
   Upload-Coverage:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     needs:
       - Unit-Tests
       - PostgreSQL-Integration-Tests


### PR DESCRIPTION
Dependabot PRs don't have access to our secrets, so it can't upload coverage reports.