### PR TITLE
Fix docker repo for golang-cross

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ release-snapshot:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
-		troian/golang-cross:${GOLANG_CROSS_VERSION} \
+		ghcr.io/troian/golang-cross:${GOLANG_CROSS_VERSION} \
 		-f .goreleaser.yml --rm-dist --snapshot --skip-validate --skip-publish
 
 .PHONY: release-dry-run
@@ -38,7 +38,7 @@ release-dry-run:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
-		troian/golang-cross:${GOLANG_CROSS_VERSION} \
+		ghcr.io/troian/golang-cross:${GOLANG_CROSS_VERSION} \
 		-f .goreleaser.yml --rm-dist --skip-validate --skip-publish
 
 .PHONY: release
@@ -54,5 +54,5 @@ release:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
-		troian/golang-cross:${GOLANG_CROSS_VERSION} \
+		ghcr.io/troian/golang-cross:${GOLANG_CROSS_VERSION} \
 		-f .goreleaser.yml release --rm-dist


### PR DESCRIPTION
The author moved from Docker Hub to Github Repos for their images https://github.com/troian/golang-cross#docker