### PR TITLE
[INTG-2028] Use correct rate limiting header

### DIFF
--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -325,16 +325,16 @@ func (a *Client) GetMedia(ctx context.Context, request *GetMediaRequest) (*GetMe
 		return nil, nil
 	}
 
-	contentType, ok := result.Header["Content-Type"]
-	if !ok {
-		return nil, fmt.Errorf("Failed to get content-type of media")
+	contentType := result.Header.Get("Content-Type")
+	if contentType == "" {
+		return nil, fmt.Errorf("failed to get content-type of media")
 	}
 
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(result.Body)
 
 	resp := &GetMediaResponse{
-		ContentType: contentType[0],
+		ContentType: contentType,
 		Body:        buf.Bytes(),
 		MediaID:     mediaID,
 	}

--- a/internal/app/api/api_test.go
+++ b/internal/app/api/api_test.go
@@ -628,7 +628,7 @@ func TestAPIClientBackoff429TooManyRequest(t *testing.T) {
 		Get(fmt.Sprintf("/audits/%s", "1234")).
 		Reply(429)
 	now := time.Now().Unix() * 1000
-	req.SetHeader("X-Rate-Limit-Reset", strconv.FormatInt(now, 10))
+	req.SetHeader("X-RateLimit-Reset", strconv.FormatInt(now, 10))
 
 	tests := []struct {
 		name string

--- a/internal/app/api/api_test.go
+++ b/internal/app/api/api_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 	"testing"
@@ -433,13 +432,11 @@ func TestGetMedia(t *testing.T) {
 	defer gock.Off()
 
 	result := `{id:"test-id"}`
-	header := make(http.Header)
-	header["Content-Type"] = []string{"test-content"}
-	req := gock.New("http://localhost:9999").
+	gock.New("http://localhost:9999").
 		Get("/audits/1234/media/12345").
 		Reply(200).
-		BodyString(result)
-	req.SetHeader("Content-Type", "test-content")
+		BodyString(result).
+		SetHeader("Content-Type", "test-content")
 
 	apiClient := api.GetTestClient()
 	gock.InterceptClient(apiClient.HTTPClient())

--- a/internal/app/api/api_test.go
+++ b/internal/app/api/api_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -627,8 +626,7 @@ func TestAPIClientBackoff429TooManyRequest(t *testing.T) {
 	req := gock.New("http://localhost:9999").
 		Get(fmt.Sprintf("/audits/%s", "1234")).
 		Reply(429)
-	now := time.Now().Unix() * 1000
-	req.SetHeader("X-RateLimit-Reset", strconv.FormatInt(now, 10))
+	req.SetHeader("X-RateLimit-Reset", "1")
 
 	tests := []struct {
 		name string

--- a/internal/app/api/http_utils.go
+++ b/internal/app/api/http_utils.go
@@ -16,7 +16,7 @@ const (
 	XRequestID         Header = "X-Request-ID"
 	IntegrationID      Header = "sc-integration-id"
 	IntegrationVersion Header = "sc-integration-version"
-	XRateLimitReset    Header = "X-Rate-Limit-Reset"
+	XRateLimitReset    Header = "X-RateLimit-Reset"
 )
 
 // HTTPDoer executes http requests.


### PR DESCRIPTION
The API is actually using `X-RateLimit-Reset` not `X-Rate-Limit-Reset`. It also returns a number of seconds NOT an epoch time.

This also adjusts the code to user `Header.Get`, instead of accessing the map directly. As this does not behave correctly when header keys are lowercased.