### PR TITLE
INTG-2235 added logging when media is downloading

### DIFF
--- a/internal/app/feed/feed_inspection_item.go
+++ b/internal/app/feed/feed_inspection_item.go
@@ -150,6 +150,7 @@ func fetchAndWriteMedia(ctx context.Context, apiClient *api.Client, exporter Exp
 }
 
 func (f *InspectionItemFeed) writeRows(ctx context.Context, exporter Exporter, rows []*InspectionItem, apiClient *api.Client) error {
+	logger := util.GetLogger()
 	skipIDs := map[string]bool{}
 	for _, id := range f.SkipIDs {
 		skipIDs[id] = true
@@ -185,6 +186,10 @@ func (f *InspectionItemFeed) writeRows(ctx context.Context, exporter Exporter, r
 			}
 
 			mediaURLList := strings.Split(row.MediaHypertextReference, "\n")
+			if len(mediaURLList) > 0 {
+				logger.Infof(" downloading media for inspection item %s", row.ItemID)
+			}
+
 			for _, mediaURL := range mediaURLList {
 				wg.Add(1)
 


### PR DESCRIPTION
Exporting to CSV when `media = true` can lead to false impression that the exporter is stuck.
Adding more logs, makes the iAuditorExporter actions more clear