### PR TITLE
[INTG-2277] add logs around http duration

### DIFF
--- a/internal/app/api/http_utils.go
+++ b/internal/app/api/http_utils.go
@@ -1,9 +1,8 @@
 package api
 
 import (
-	"net/http"
-
 	"github.com/dghubble/sling"
+	"net/http"
 )
 
 // Header is used to represent name of a header

--- a/internal/app/feed/feed_action.go
+++ b/internal/app/feed/feed_action.go
@@ -136,7 +136,7 @@ func (f *ActionFeed) Export(ctx context.Context, apiClient *api.Client, exporter
 			}
 		}
 
-		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)
+		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_group.go
+++ b/internal/app/feed/feed_group.go
@@ -96,7 +96,7 @@ func (f *GroupFeed) Export(ctx context.Context, apiClient *api.Client, exporter 
 			}
 		}
 
-		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)
+		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_group_user.go
+++ b/internal/app/feed/feed_group_user.go
@@ -101,7 +101,7 @@ func (f *GroupUserFeed) Export(ctx context.Context, apiClient *api.Client, expor
 			}
 		}
 
-		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)
+		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_inspection.go
+++ b/internal/app/feed/feed_inspection.go
@@ -192,7 +192,7 @@ func (f *InspectionFeed) Export(ctx context.Context, apiClient *api.Client, expo
 			util.Check(err, "Failed to write data to exporter")
 		}
 
-		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)
+		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_inspection_item.go
+++ b/internal/app/feed/feed_inspection_item.go
@@ -257,7 +257,7 @@ func (f *InspectionItemFeed) Export(ctx context.Context, apiClient *api.Client, 
 			util.Check(err, "Failed to write data to exporter")
 		}
 
-		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)
+		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_issue.go
+++ b/internal/app/feed/feed_issue.go
@@ -117,7 +117,7 @@ func (f *IssueFeed) Export(ctx context.Context, apiClient *api.Client, exporter 
 			}
 		}
 
-		logger.Infof("%s: %d remaining", f.Name(), resp.Metadata.RemainingRecords)
+		logger.Infof("%s: %d remaining. Last call was %dms", f.Name(), resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
 		return nil
 	}
 

--- a/internal/app/feed/feed_schedule.go
+++ b/internal/app/feed/feed_schedule.go
@@ -128,7 +128,7 @@ func (f *ScheduleFeed) Export(ctx context.Context, apiClient *api.Client, export
 			}
 		}
 
-		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)
+		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_schedule_assginee.go
+++ b/internal/app/feed/feed_schedule_assginee.go
@@ -105,7 +105,7 @@ func (f *ScheduleAssigneeFeed) Export(ctx context.Context, apiClient *api.Client
 			}
 		}
 
-		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)
+		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_schedule_occurrence.go
+++ b/internal/app/feed/feed_schedule_occurrence.go
@@ -118,7 +118,7 @@ func (f *ScheduleOccurrenceFeed) Export(ctx context.Context, apiClient *api.Clie
 			}
 		}
 
-		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)
+		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_site.go
+++ b/internal/app/feed/feed_site.go
@@ -113,7 +113,7 @@ func (f *SiteFeed) Export(ctx context.Context, apiClient *api.Client, exporter E
 			}
 		}
 
-		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)
+		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_template.go
+++ b/internal/app/feed/feed_template.go
@@ -120,7 +120,7 @@ func (f *TemplateFeed) Export(ctx context.Context, apiClient *api.Client, export
 			}
 		}
 
-		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)
+		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_template_permission.go
+++ b/internal/app/feed/feed_template_permission.go
@@ -104,7 +104,7 @@ func (f *TemplatePermissionFeed) Export(ctx context.Context, apiClient *api.Clie
 			}
 		}
 
-		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)
+		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_user.go
+++ b/internal/app/feed/feed_user.go
@@ -104,7 +104,7 @@ func (f *UserFeed) Export(ctx context.Context, apiClient *api.Client, exporter E
 			}
 		}
 
-		logger.Infof("%s: %d remaining", feedName, resp.Metadata.RemainingRecords)
+		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
 		return nil
 	})
 	util.Check(err, "Failed to export feed")


### PR DESCRIPTION
To properly analyse customer complaints related to the slowness, I added logs around HTTP calls

2022-05-11T11:20:05.889+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 147 remaining. Last call was 903ms
2022-05-11T11:20:08.290+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 127 remaining. Last call was 877ms
2022-05-11T11:20:10.994+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 107 remaining. Last call was 929ms
2022-05-11T11:20:13.149+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 87 remaining. Last call was 682ms
2022-05-11T11:20:16.999+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 67 remaining. Last call was 493ms
2022-05-11T11:20:19.861+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 47 remaining. Last call was 869ms
2022-05-11T11:20:22.381+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 27 remaining. Last call was 575ms
2022-05-11T11:20:25.069+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 7 remaining. Last call was 1175ms
2022-05-11T11:20:26.059+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 0 remaining. Last call was 426ms