### PR TITLE
[INTG-2277] add logs to actions, inspections, and inspection_items

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Setup release environment
         run: |-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/internal/app/feed/export_feeds.go
+++ b/internal/app/feed/export_feeds.go
@@ -23,7 +23,7 @@ func GetFeeds(v *viper.Viper) []Feed {
 	sitesIncludeFullHierarchy := viper.GetBool("export.site.include_full_hierarchy")
 
 	return []Feed{
-		getInspectionFeed(v, inspectionConfig, templateIDs),
+		getInspectionFeed(inspectionConfig, templateIDs),
 		&InspectionItemFeed{
 			SkipIDs:         inspectionConfig.SkipIDs,
 			ModifiedAfter:   inspectionConfig.ModifiedAfter,
@@ -91,7 +91,7 @@ func GetIssueLimit(v *viper.Viper) int {
 	return 100
 }
 
-func getInspectionFeed(v *viper.Viper, inspectionConfig *config.InspectionConfig, templateIDs []string) *InspectionFeed {
+func getInspectionFeed(inspectionConfig *config.InspectionConfig, templateIDs []string) *InspectionFeed {
 	return &InspectionFeed{
 		SkipIDs:       inspectionConfig.SkipIDs,
 		ModifiedAfter: inspectionConfig.ModifiedAfter,
@@ -191,7 +191,7 @@ func ExportInspectionReports(v *viper.Viper, apiClient *api.Client, exporter *Re
 
 	logger.Infof("Exporting inspection reports by user: %s %s", resp.Firstname, resp.Lastname)
 
-	feed := getInspectionFeed(v, config.GetInspectionConfig(v), getTemplateIDs(v))
+	feed := getInspectionFeed(config.GetInspectionConfig(v), getTemplateIDs(v))
 	err = feed.Export(ctx, apiClient, exporter, resp.OrganisationID)
 	util.Check(err, "failed to export inspection feed")
 

--- a/internal/app/feed/exporter_csv.go
+++ b/internal/app/feed/exporter_csv.go
@@ -14,12 +14,10 @@ import (
 // CSVExporter is an interface to export data feeds to CSV files
 type CSVExporter struct {
 	*SQLExporter
-
-	ExportPath string
-
+	ExportPath     string
 	MaxRowsPerFile int
-
-	Logger *zap.SugaredLogger
+	Logger         *zap.SugaredLogger
+	duration       time.Duration
 }
 
 // CreateSchema generated schema for a feed in csv format
@@ -160,6 +158,10 @@ func (e *CSVExporter) cleanOldFiles(feedName string) error {
 	return nil
 }
 
+func (e *CSVExporter) GetDuration() time.Duration {
+	return e.duration
+}
+
 func fileExists(filename string) (bool, error) {
 	info, err := os.Stat(filename)
 	if os.IsNotExist(err) {
@@ -185,5 +187,6 @@ func NewCSVExporter(exportPath, exportMediaPath string, maxRowsPerFile int) (*CS
 		ExportPath:     exportPath,
 		MaxRowsPerFile: maxRowsPerFile,
 		Logger:         sqlExporter.Logger,
+		duration:       0,
 	}, nil
 }

--- a/internal/app/feed/exporter_csv.go
+++ b/internal/app/feed/exporter_csv.go
@@ -158,7 +158,9 @@ func (e *CSVExporter) cleanOldFiles(feedName string) error {
 	return nil
 }
 
+// GetDuration will return the duration for exporting a batch
 func (e *CSVExporter) GetDuration() time.Duration {
+	// NOT IMPLEMENTED
 	return e.duration
 }
 

--- a/internal/app/feed/exporter_report.go
+++ b/internal/app/feed/exporter_report.go
@@ -210,6 +210,11 @@ func (e *ReportExporter) saveReport(ctx context.Context, apiClient *api.Client, 
 	return report
 }
 
+func (e *ReportExporter) GetDuration() time.Duration {
+	// NOT IMPLEMENTED
+	return 0
+}
+
 func (e *ReportExporter) exportInspection(ctx context.Context, apiClient *api.Client, inspection *Inspection, format string) error {
 	messageID, err := apiClient.InitiateInspectionReportExport(ctx, inspection.ID, format, e.PreferenceID)
 	if err != nil {
@@ -358,8 +363,6 @@ func getFilePath(exportPath string, inspection *Inspection, format string, filen
 			return "", err
 		}
 	}
-
-	return "", nil
 }
 
 // NewReportExporter returns a new instance of ReportExporter

--- a/internal/app/feed/exporter_report.go
+++ b/internal/app/feed/exporter_report.go
@@ -210,6 +210,7 @@ func (e *ReportExporter) saveReport(ctx context.Context, apiClient *api.Client, 
 	return report
 }
 
+// GetDuration will return the duration for exporting a batch
 func (e *ReportExporter) GetDuration() time.Duration {
 	// NOT IMPLEMENTED
 	return 0

--- a/internal/app/feed/exporter_schema.go
+++ b/internal/app/feed/exporter_schema.go
@@ -3,6 +3,7 @@ package feed
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/olekukonko/tablewriter"
 
@@ -52,6 +53,11 @@ func (e *SchemaExporter) WriteSchema(feed Feed) error {
 	table.Render()
 
 	return nil
+}
+
+func (e *SchemaExporter) GetDuration() time.Duration {
+	// NOT IMPLEMENTED
+	return 0
 }
 
 // NewSchemaExporter creates a new instance of SchemaExporter

--- a/internal/app/feed/exporter_schema.go
+++ b/internal/app/feed/exporter_schema.go
@@ -55,6 +55,7 @@ func (e *SchemaExporter) WriteSchema(feed Feed) error {
 	return nil
 }
 
+// GetDuration will return the duration for exporting a batch
 func (e *SchemaExporter) GetDuration() time.Duration {
 	// NOT IMPLEMENTED
 	return 0

--- a/internal/app/feed/exporter_sql.go
+++ b/internal/app/feed/exporter_sql.go
@@ -73,6 +73,7 @@ func (e *SQLExporter) InitFeed(feed Feed, opts *InitFeedOptions) error {
 	return nil
 }
 
+// GetDuration will return the duration for exporting a batch
 func (e *SQLExporter) GetDuration() time.Duration {
 	return e.duration
 }

--- a/internal/app/feed/feed.go
+++ b/internal/app/feed/feed.go
@@ -2,6 +2,7 @@ package feed
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/SafetyCulture/iauditor-exporter/internal/app/api"
@@ -36,7 +37,38 @@ type Exporter interface {
 	LastModifiedAt(feed Feed, modifiedAfter time.Time, orgID string) (time.Time, error)
 	WriteMedia(auditID string, mediaID string, contentType string, body []byte) error
 	DeleteRowsIfExist(feed Feed, query string, args ...interface{}) error
+	GetDuration() time.Duration
 
 	SupportsUpsert() bool
 	ParameterLimit() int
+}
+
+// LogStringConfig is the config for GetLogString function
+type LogStringConfig struct {
+	RemainingRecords int64
+	HttpDuration     time.Duration
+	ExporterDuration time.Duration
+}
+
+// GetLogString build a log string based on input arguments
+func GetLogString(feedName string, cfg *LogStringConfig) string {
+	var args = []any{feedName}
+	var format = "%s: "
+
+	if cfg != nil {
+		format = format + "%d remaining."
+		args = append(args, cfg.RemainingRecords)
+
+		if cfg.HttpDuration.Milliseconds() != 0 {
+			format = format + " Last http call was %dms."
+			args = append(args, cfg.HttpDuration.Milliseconds())
+		}
+
+		if cfg.ExporterDuration.Milliseconds() != 0 {
+			format = format + " Last export operation was %dms."
+			args = append(args, cfg.ExporterDuration.Milliseconds())
+		}
+	}
+
+	return fmt.Sprintf(format, args...)
 }

--- a/internal/app/feed/feed.go
+++ b/internal/app/feed/feed.go
@@ -46,7 +46,7 @@ type Exporter interface {
 // LogStringConfig is the config for GetLogString function
 type LogStringConfig struct {
 	RemainingRecords int64
-	HttpDuration     time.Duration
+	HTTPDuration     time.Duration
 	ExporterDuration time.Duration
 }
 
@@ -59,9 +59,9 @@ func GetLogString(feedName string, cfg *LogStringConfig) string {
 		format = format + "%d remaining."
 		args = append(args, cfg.RemainingRecords)
 
-		if cfg.HttpDuration.Milliseconds() != 0 {
+		if cfg.HTTPDuration.Milliseconds() != 0 {
 			format = format + " Last http call was %dms."
-			args = append(args, cfg.HttpDuration.Milliseconds())
+			args = append(args, cfg.HTTPDuration.Milliseconds())
 		}
 
 		if cfg.ExporterDuration.Milliseconds() != 0 {

--- a/internal/app/feed/feed_action.go
+++ b/internal/app/feed/feed_action.go
@@ -138,7 +138,7 @@ func (f *ActionFeed) Export(ctx context.Context, apiClient *api.Client, exporter
 
 		logger.Info(GetLogString(f.Name(), &LogStringConfig{
 			RemainingRecords: resp.Metadata.RemainingRecords,
-			HttpDuration:     apiClient.Duration,
+			HTTPDuration:     apiClient.Duration,
 			ExporterDuration: exporter.GetDuration(),
 		}))
 		return nil

--- a/internal/app/feed/feed_action.go
+++ b/internal/app/feed/feed_action.go
@@ -136,7 +136,11 @@ func (f *ActionFeed) Export(ctx context.Context, apiClient *api.Client, exporter
 			}
 		}
 
-		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
+		logger.Info(GetLogString(f.Name(), &LogStringConfig{
+			RemainingRecords: resp.Metadata.RemainingRecords,
+			HttpDuration:     apiClient.Duration,
+			ExporterDuration: exporter.GetDuration(),
+		}))
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_inspection.go
+++ b/internal/app/feed/feed_inspection.go
@@ -192,7 +192,11 @@ func (f *InspectionFeed) Export(ctx context.Context, apiClient *api.Client, expo
 			util.Check(err, "Failed to write data to exporter")
 		}
 
-		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
+		logger.Info(GetLogString(f.Name(), &LogStringConfig{
+			RemainingRecords: resp.Metadata.RemainingRecords,
+			HttpDuration:     apiClient.Duration,
+			ExporterDuration: exporter.GetDuration(),
+		}))
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_inspection.go
+++ b/internal/app/feed/feed_inspection.go
@@ -194,7 +194,7 @@ func (f *InspectionFeed) Export(ctx context.Context, apiClient *api.Client, expo
 
 		logger.Info(GetLogString(f.Name(), &LogStringConfig{
 			RemainingRecords: resp.Metadata.RemainingRecords,
-			HttpDuration:     apiClient.Duration,
+			HTTPDuration:     apiClient.Duration,
 			ExporterDuration: exporter.GetDuration(),
 		}))
 		return nil

--- a/internal/app/feed/feed_inspection_item.go
+++ b/internal/app/feed/feed_inspection_item.go
@@ -257,7 +257,11 @@ func (f *InspectionItemFeed) Export(ctx context.Context, apiClient *api.Client, 
 			util.Check(err, "Failed to write data to exporter")
 		}
 
-		logger.Infof("%s: %d remaining. Last call was %dms", feedName, resp.Metadata.RemainingRecords, apiClient.Duration.Milliseconds())
+		logger.Info(GetLogString(f.Name(), &LogStringConfig{
+			RemainingRecords: resp.Metadata.RemainingRecords,
+			HttpDuration:     apiClient.Duration,
+			ExporterDuration: exporter.GetDuration(),
+		}))
 		return nil
 	})
 	util.Check(err, "Failed to export feed")

--- a/internal/app/feed/feed_inspection_item.go
+++ b/internal/app/feed/feed_inspection_item.go
@@ -259,7 +259,7 @@ func (f *InspectionItemFeed) Export(ctx context.Context, apiClient *api.Client, 
 
 		logger.Info(GetLogString(f.Name(), &LogStringConfig{
 			RemainingRecords: resp.Metadata.RemainingRecords,
-			HttpDuration:     apiClient.Duration,
+			HTTPDuration:     apiClient.Duration,
 			ExporterDuration: exporter.GetDuration(),
 		}))
 		return nil

--- a/internal/app/feed/feed_test.go
+++ b/internal/app/feed/feed_test.go
@@ -1,0 +1,47 @@
+package feed_test
+
+import (
+	"github.com/SafetyCulture/iauditor-exporter/internal/app/feed"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestGetLogString_WhenNoArgumentsArePassed(t *testing.T) {
+	result := feed.GetLogString("TEST_FEED", nil)
+	assert.EqualValues(t, "TEST_FEED: ", result)
+}
+
+func TestGetLogString_WhenMinimumArgumentsArePassed(t *testing.T) {
+	cfg := feed.LogStringConfig{RemainingRecords: 10}
+	result := feed.GetLogString("TEST_FEED", &cfg)
+	assert.EqualValues(t, "TEST_FEED: 10 remaining.", result)
+}
+
+func TestGetLogString_WhenHTTPDuration(t *testing.T) {
+	cfg := feed.LogStringConfig{
+		RemainingRecords: 40,
+		HttpDuration:     time.Second * 5,
+	}
+	result := feed.GetLogString("TEST_FEED", &cfg)
+	assert.EqualValues(t, "TEST_FEED: 40 remaining. Last http call was 5000ms.", result)
+}
+
+func TestGetLogString_WhenExporterDuration(t *testing.T) {
+	cfg := feed.LogStringConfig{
+		RemainingRecords: 20,
+		ExporterDuration: time.Second * 2,
+	}
+	result := feed.GetLogString("TEST_FEED", &cfg)
+	assert.EqualValues(t, "TEST_FEED: 20 remaining. Last export operation was 2000ms.", result)
+}
+
+func TestGetLogString_WhenAllDataIsPresent(t *testing.T) {
+	cfg := feed.LogStringConfig{
+		RemainingRecords: 50,
+		ExporterDuration: time.Second * 1,
+		HttpDuration:     time.Millisecond * 44,
+	}
+	result := feed.GetLogString("TEST_FEED", &cfg)
+	assert.EqualValues(t, "TEST_FEED: 50 remaining. Last http call was 44ms. Last export operation was 1000ms.", result)
+}

--- a/internal/app/feed/feed_test.go
+++ b/internal/app/feed/feed_test.go
@@ -21,7 +21,7 @@ func TestGetLogString_WhenMinimumArgumentsArePassed(t *testing.T) {
 func TestGetLogString_WhenHTTPDuration(t *testing.T) {
 	cfg := feed.LogStringConfig{
 		RemainingRecords: 40,
-		HttpDuration:     time.Second * 5,
+		HTTPDuration:     time.Second * 5,
 	}
 	result := feed.GetLogString("TEST_FEED", &cfg)
 	assert.EqualValues(t, "TEST_FEED: 40 remaining. Last http call was 5000ms.", result)
@@ -40,7 +40,7 @@ func TestGetLogString_WhenAllDataIsPresent(t *testing.T) {
 	cfg := feed.LogStringConfig{
 		RemainingRecords: 50,
 		ExporterDuration: time.Second * 1,
-		HttpDuration:     time.Millisecond * 44,
+		HTTPDuration:     time.Millisecond * 44,
 	}
 	result := feed.GetLogString("TEST_FEED", &cfg)
 	assert.EqualValues(t, "TEST_FEED: 50 remaining. Last http call was 44ms. Last export operation was 1000ms.", result)


### PR DESCRIPTION
Added logs to SQL writes for actions/inspections/inspection_items

`2022-05-16T15:13:35.825+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 114 remaining. Last http call was 965ms. Last export operation was 34ms.

2022-05-16T15:13:38.328+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 94 remaining. Last http call was 906ms. Last export operation was 72ms.

2022-05-16T15:13:40.986+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 74 remaining. Last http call was 991ms. Last export operation was 58ms.

2022-05-16T15:13:43.260+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 54 remaining. Last http call was 789ms. Last export operation was 42ms.

2022-05-16T15:13:46.214+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 34 remaining. Last http call was 1220ms. Last export operation was 127ms.

2022-05-16T15:13:50.201+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 14 remaining. Last http call was 1094ms. Last export operation was 154ms.

2022-05-16T15:13:52.167+1000	INFO	iauditor-exporter@0.0.0-dev	inspection_items: 0 remaining. Last http call was 592ms. Last export operation was 105ms.`