### PR TITLE
Pin GOLANG_CROSS_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE_NAME        	:= "github.com/safetyculture/iauditor-exporter"
-GOLANG_CROSS_VERSION  := v1.18.2
+GOLANG_CROSS_VERSION  := v1.18.1
 
 .PHONY: help
 help:


### PR DESCRIPTION
There is a bug in goreleaser 1.9.0 that is fixed in 1.9.2, however Golang cross has not pulled this in yet. Reverting for now so we can release.

https://github.com/SafetyCulture/iauditor-exporter/runs/6748337684?check_suite_focus=true#step:5:124